### PR TITLE
Removing line numbers (which display poorly in docs.threatconnect.com)

### DIFF
--- a/docs/src/building_apps.rst
+++ b/docs/src/building_apps.rst
@@ -31,8 +31,6 @@ tcex.json Format
 ----------------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     {
       "profiles": [{
@@ -74,8 +72,6 @@ Staging Redis Data
 In order to test using variable inputs the data must be manually added to Redis.  The code below will simulate an upstream App writing data to Redis.  This code can be saved to a script ``redis-create.py`` and added to the ``tcex.json`` as a profile.  By doing this the local Testing enviroment can be simulate a piece of a running playbook.
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
 
     """ standard """
     import os

--- a/docs/src/exit.rst
+++ b/docs/src/exit.rst
@@ -17,8 +17,6 @@ Some failures do not warrant an immediate exit.  In such case the :py:meth:`~tce
 **Example**
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 8,12
 
     tcex = TcEx()
@@ -39,8 +37,6 @@ Immediate Exit on Failure
 Certain failures require that the App exit immediately.  In these cases calling the :py:meth:`~tcex.tcex.TcEx.exit` method while passing the exit code will immediately halt execution of the App and notify the ThreatConnect Platform of a failure.
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 8
 
     tcex = TcEx()

--- a/docs/src/jobs.rst
+++ b/docs/src/jobs.rst
@@ -15,8 +15,6 @@ Groups
 The :py:meth:`~tcex.tcex_job.TcExJob.group` method accepts the following data structure. All required fields are highlighted.
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 8,16
 
     {
@@ -42,8 +40,6 @@ The :py:meth:`~tcex.tcex_job.TcExJob.group` method accepts the following data st
 The module provides the :py:mod:`~tcex.tcex_job.TcExJob.group_results` property to get the status of each Group submitted.
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 2-5,8
 
     {
@@ -69,8 +65,6 @@ Group Associations
 The :py:meth:`~tcex.tcex_job.TcExJob.group_association` method accepts the following data structure. All required fields are highlighted.
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 2-5
 
     {
@@ -89,8 +83,6 @@ Indicators
 The :py:meth:`~tcex.tcex_job.TcExJob.indicator` method accepts the following data structure. All required fields are highlighted.
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14,22
 
     {
@@ -120,8 +112,6 @@ The :py:meth:`~tcex.tcex_job.TcExJob.indicator` method accepts the following dat
 The module provides the :py:mod:`~tcex.tcex_job.TcExJob.indicator_results` property to get the status of each Indicator submitted.
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 2,5,8,14
 
     {
@@ -157,8 +147,6 @@ File Occurrence
 The :py:meth:`~tcex.tcex_job.TcExJob.file_occurrence` method accepts the following data structure. All required fields are highlighted.
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 4
 
     {
@@ -176,8 +164,6 @@ Sample Job Flow
 The key method calls are highlighted in the following code sample.
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 12,18,24,32,34-37
 
     from tcex import TcEx

--- a/docs/src/logging.rst
+++ b/docs/src/logging.rst
@@ -11,8 +11,6 @@ The ThreatConnect |trade| TcEx App Framework has a built-in logger that will log
 **Example Logging**
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
 
     tcex.log.debug('logging debug')
     tcex.log.info('logging info')

--- a/docs/src/message_tc.rst
+++ b/docs/src/message_tc.rst
@@ -15,8 +15,6 @@ All ThreatConnect |trade| Exchange Apps should write an exit message on successf
 **Example Exit Message**
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 9,14
 
     tcex = TcEx()

--- a/docs/src/parser.rst
+++ b/docs/src/parser.rst
@@ -39,8 +39,6 @@ Custom arguments can be added to the ``argparser.ArgParser`` instance of :py:mod
 **Example**
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 4-6
 
     from tcex import TcEx

--- a/docs/src/proxies.rst
+++ b/docs/src/proxies.rst
@@ -14,8 +14,6 @@ Example Request using Proxy
 ---------------------------
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 2,3
 
     r = tcex.request

--- a/docs/src/request.rst
+++ b/docs/src/request.rst
@@ -10,8 +10,6 @@ Example Request
 ---------------
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
 
     r = tcex.request
     r.url = 'https://remote_api.example'

--- a/docs/src/resource.rst
+++ b/docs/src/resource.rst
@@ -10,8 +10,6 @@ The ThreatConnect |trade| TcEx Framework provides access to the ThreatConnect AP
 **Direct Access**
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 3-5
 
     tcex = TcEx()
@@ -27,8 +25,6 @@ The ThreatConnect |trade| TcEx Framework provides access to the ThreatConnect AP
 **Dynamic Access**
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 3-5
 
     tcex = TcEx()

--- a/docs/src/resource_data_store.rst
+++ b/docs/src/resource_data_store.rst
@@ -7,8 +7,6 @@ Create Entry
 ============
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14-16
 
     """ standard """
@@ -37,8 +35,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     {
         "_type": "24$tcex",
@@ -57,8 +53,6 @@ Read Entry
 ==========
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14-15
 
     """ standard """
@@ -86,8 +80,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     {
         "_type": "24$tcex",
@@ -104,8 +96,6 @@ Update Entry
 ============
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14-16
 
     """ standard """
@@ -134,8 +124,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     {
         "_type": "24$tcex",
@@ -154,8 +142,6 @@ Delete Entry
 ============
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14-15
 
     """ standard """
@@ -183,8 +169,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     {
         "_type": "24$tcex",

--- a/docs/src/resource_indicators.rst
+++ b/docs/src/resource_indicators.rst
@@ -33,8 +33,6 @@ Retrieve All Indicators
 =======================
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14,18
 
     """ standard """
@@ -69,8 +67,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     [{
         "rating": 5.0,
@@ -108,8 +104,6 @@ Retrieve Specific Indicator
 ===========================
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14,17,19
 
     """ standard """
@@ -140,8 +134,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     {
         "rating": 5.0,
@@ -165,8 +157,6 @@ Retrieve Filtered Indicators
 ============================
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14,17-18,20
 
     """ standard """
@@ -203,8 +193,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     [{
         "rating": 5.0,
@@ -241,8 +229,6 @@ Indicator Associations
 ======================
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14,17-18,20
 
     """ standard """
@@ -293,8 +279,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     [{
         "rating": 5.0,

--- a/docs/src/resource_security_labels.rst
+++ b/docs/src/resource_security_labels.rst
@@ -8,8 +8,6 @@ Retrieve All Security Labels
 ============================
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14,18
 
     """ standard """
@@ -44,8 +42,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     [{
         "dateAdded": "2017-01-04T20:07:00Z",
@@ -62,8 +58,6 @@ Retrieve Specific Security Label
 ================================
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14,17,19
 
     """ standard """
@@ -95,8 +89,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     {
         "dateAdded": "2017-01-04T20:07:00Z",
@@ -109,8 +101,6 @@ Retrieve Filtered Security Labels
 =================================
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14,17,19
 
     """ standard """
@@ -146,8 +136,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
 
     [{

--- a/docs/src/resource_tags.rst
+++ b/docs/src/resource_tags.rst
@@ -7,8 +7,6 @@ Retrieve All Tags
 =================
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14,18
 
     """ standard """
@@ -43,8 +41,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     [{
         "name": "APT",
@@ -68,8 +64,6 @@ Retrieve Specific Tag
 =====================
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14,17,19
 
     """ standard """
@@ -101,8 +95,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     {
         "name": "APT",
@@ -114,8 +106,6 @@ Retrieve Filtered Tags
 ======================
 
 .. code-block:: python
-    :linenos:
-    :lineno-start: 1
     :emphasize-lines: 14,17,19
 
     """ standard """
@@ -151,8 +141,6 @@ Response
 --------
 
 .. code-block:: javascript
-    :linenos:
-    :lineno-start: 1
 
     [{
         "name": "APT",


### PR DESCRIPTION
I'm removing the line numbers from the docs as they display poorly in docs.threatconnect.com.

Merging this fixes https://github.com/ThreatConnect-Inc/ThreatConnect_Developer_Docs/issues/199 .