### PR TITLE
Define an empty self.config so that the --config file is optional

### DIFF
--- a/bin/tcpackage
+++ b/bin/tcpackage
@@ -72,6 +72,8 @@ class TcPackage(object):
                 except ValueError as e:
                     print('Invalid JSON File {}{}({})'.format(c.Style.BRIGHT, c.Fore.RED, e))
                     sys.exit(1)
+        else:
+            self.config = {}
 
     def _load_schema(self):
         """Load JSON schema file"""


### PR DESCRIPTION
Without this, calling `tcpackage` without a config file set with the  `--config` argument, returns an error. 