### PR TITLE
Adding warning message about the required setup.cfg file for macOS

### DIFF
--- a/docs/src/building_apps_modules.rst
+++ b/docs/src/building_apps_modules.rst
@@ -4,6 +4,13 @@ Running ``tclib`` will download/install all required Python dependencies defined
 
 .. note:: Typically calling ``tclib`` with no arguments is the most common use case.  If building an App for distribution then using a configuration file to define the lib structure is preferable.  The alternative is to run tclib using each Python version the App should support.
 
+.. warning:: If you are using **macOS** and have Python installed via Homebrew, there is a `known bug <https://stackoverflow.com/questions/24257803/distutilsoptionerror-must-supply-either-home-or-prefix-exec-prefix-not-both>`__ that requires you to create a ``setup.cfg`` file in the same directory as the ``requirements.txt``. The ``setup.cfg`` file should have the following code:
+
+  .. code-block:: python
+
+    [install]
+    prefix=
+
 Usage
 -----
 


### PR DESCRIPTION
This is to fix https://github.com/ThreatConnect-Inc/threatconnect-developer-docs/issues/226 .