### PR TITLE
Adding a warning message if no "xid" is given when creating groups/indicators

### DIFF
--- a/tcex/tcex_batch_v2.py
+++ b/tcex/tcex_batch_v2.py
@@ -294,10 +294,7 @@ class TcExBatch(object):
         """
         # make sure there is an "xid" key-value pair
         if not group_data.get('xid'):
-            message = 'An "xid" key-value pair is necessary to create a group (see {}).'.format(
-                      'https://docs.threatconnect.com/en/latest/tcex/batch.html#group-interface-3')
-            self.tcex.log.error(message)
-            raise KeyError(message)
+            self.tcex.handle_error(500)
         return self._group(group_data)
 
     def add_indicator(self, indicator_data):
@@ -338,10 +335,7 @@ class TcExBatch(object):
         """
         # make sure there is an "xid" key-value pair
         if not indicator_data.get('xid'):
-            message = 'An "xid" key-value pair is necessary to create an indicator (see {}).'.format(
-                      'https://docs.threatconnect.com/en/latest/tcex/batch.html#indicator-interface-3')
-            self.tcex.log.error(message)
-            raise KeyError(message)
+            self.tcex.handle_error(501)
 
         if indicator_data.get('type') not in ['Address', 'EmailAddress', 'File', 'Host', 'URL']:
             # for custom indicator types the valueX fields are required.

--- a/tcex/tcex_batch_v2.py
+++ b/tcex/tcex_batch_v2.py
@@ -292,6 +292,12 @@ class TcExBatch(object):
             group_data (dict): The full Group data including attributes, labels, tags, and
                 associations.
         """
+        # make sure there is an "xid" key-value pair
+        if not group_data.get('xid'):
+            message = 'An "xid" key-value pair is necessary to create a group (see {}).'.format(
+                      'https://docs.threatconnect.com/en/latest/tcex/batch.html#group-interface-3')
+            self.tcex.log.error(message)
+            raise KeyError(message)
         return self._group(group_data)
 
     def add_indicator(self, indicator_data):
@@ -330,6 +336,13 @@ class TcExBatch(object):
             indicator_data (dict): The Full Indicator data including attributes, labels, tags,
                 and associations.
         """
+        # make sure there is an "xid" key-value pair
+        if not indicator_data.get('xid'):
+            message = 'An "xid" key-value pair is necessary to create an indicator (see {}).'.format(
+                      'https://docs.threatconnect.com/en/latest/tcex/batch.html#indicator-interface-3')
+            self.tcex.log.error(message)
+            raise KeyError(message)
+
         if indicator_data.get('type') not in ['Address', 'EmailAddress', 'File', 'Host', 'URL']:
             # for custom indicator types the valueX fields are required.
             # using the summary we can build the values

--- a/tcex/tcex_error_codes.py
+++ b/tcex/tcex_error_codes.py
@@ -25,6 +25,10 @@ class TcExErrorCodes(object):
             305: 'An invalid action/association name ({}) was provided.',
             350: 'Data Store request failed. API status code: {}, API message: {}.',
             # batch v2: 500-600
+            500: 'An "xid" key-value pair was not found and is necessary to create a group ' + \
+                 '(see {}).'.format('https://docs.threatconnect.com/en/latest/tcex/batch.html#group-interface-3'),
+            501: 'An "xid" key-value pair was not found and is necessary to create an indicator ' + \
+                 '(see {}).'.format('https://docs.threatconnect.com/en/latest/tcex/batch.html#indicator-interface-3'),
             520: 'File Occurrences can only be added to a File. Current type: {}.',
             540: 'Failed polling batch status ({}).',
             545: 'Failed polling batch status. API status code: {}, API message: {}.',

--- a/tests/tcex_tests.py
+++ b/tests/tcex_tests.py
@@ -13,6 +13,7 @@ tcex_instance.log.debug('Creating content in {}. If this is not correct, pass in
 cleaner.clean(tcex_instance)
 
 # call the test functions
+batch_group_creation_test.group_create_without_xid(tcex_instance)
 batch_group_creation_test.test_interface_1(tcex_instance)
 batch_group_creation_test.test_interface_2(tcex_instance)
 batch_group_creation_test.test_interface_3(tcex_instance)

--- a/tests/testing_scripts/batch_group_creation_test.py
+++ b/tests/testing_scripts/batch_group_creation_test.py
@@ -66,3 +66,27 @@ def test_interface_3(tcex):
     batch.submit_all()
     validator.validate(tcex, expected_groups=11)
     cleaner.clean(tcex)
+
+
+def group_create_without_xid(tcex):
+    """Try to create an adversary without an XID to make sure a key-error is thrown."""
+    owner = tcex.args.api_default_org
+    batch_job = tcex.batch(owner)
+    try:
+        batch_job.add_group({
+            'name': 'adversary-broken',
+            'type': 'Adversary',
+            'attribute': [{
+                "displayed": True,
+                "type": "Description",
+                "value": "Example Description"
+            }],
+            'tag': [{
+                'name': 'Example Tag'
+            }]
+        })
+    except KeyError:
+        # we can move on if a KeyError is thrown - we are expecting a KeyError
+        pass
+    else:
+        raise RuntimeError('No "KeyError" was thrown when trying to create an adversary without an xid')


### PR DESCRIPTION
Not sure if we want to add this or not, so I'm creating this PR. This just makes it easier to debug missing cases where the "xid" key-value pair is missing using interface 3 (https://docs.threatconnect.com/en/latest/tcex/batch.html#group-interface-3 or https://docs.threatconnect.com/en/latest/tcex/batch.html#indicator-interface-3).