### PR TITLE
Removing overly broad exception handling

### DIFF
--- a/app_init/playbook/run.py
+++ b/app_init/playbook/run.py
@@ -63,17 +63,14 @@ if __name__ == '__main__':
             tc_action = app.args.tc_action
             tc_action_formatted = tc_action.lower().replace(' ', '_')
             tc_action_map = 'tc_action_map'  # reserved property name for action to method map
-            try:
-                # run action method
-                if hasattr(app, tc_action):
-                    getattr(app, tc_action)()
-                elif hasattr(app, tc_action_formatted):
-                    getattr(app, tc_action_formatted)()
-                elif hasattr(app, tc_action_map):
-                    app.tc_action_map.get(app.args.tc_action)()
-                else:
-                    tcex.exit(1, 'Action method ({}) was not found.'.format(app.args.tc_action))
-            except (AttributeError, TypeError):
+            # run action method
+            if hasattr(app, tc_action):
+                getattr(app, tc_action)()
+            elif hasattr(app, tc_action_formatted):
+                getattr(app, tc_action_formatted)()
+            elif hasattr(app, tc_action_map):
+                app.tc_action_map.get(app.args.tc_action)()
+            else:
                 tcex.exit(1, 'Action method ({}) was not found.'.format(app.args.tc_action))
         else:
             # default to run method


### PR DESCRIPTION
The `try... except` block in the run.py for playbook action apps is too broad. With the `try... except` block in the run.py, if the function being called fails with an `AttributeError` or `TypeError`, it is caught by the try-except block in run.py and gives an erroneous error message.