### PR TITLE
Removing the section that runs the write_output function

### DIFF
--- a/tcex/testing/test_case_job.py
+++ b/tcex/testing/test_case_job.py
@@ -46,11 +46,6 @@ class TestCaseJob(TestCase):
         if exit_code != 0:
             return exit_code
 
-        # Write Output
-        exit_code = self.run_app_method(app, 'write_output')
-        if exit_code != 0:
-            return exit_code
-
         # Done
         exit_code = self.run_app_method(app, 'done')
         if exit_code != 0:


### PR DESCRIPTION
The `write_output` function does not (normally) exist in job apps, so I've removed the part of the code that runs this function when testing a job app.