### PR TITLE
Add assert introspection for modules in tests/helpers

### DIFF
--- a/app_init/tests/conftest.py
+++ b/app_init/tests/conftest.py
@@ -4,6 +4,11 @@ import os
 import shutil
 import sys
 
+import pytest
+
+# Add assert introspection (actual vs expected logging) for ALL files in the `helpers` folder.
+pytest.register_assert_rewrite('tests.helpers')
+
 
 # clear log directory
 def clear_log_directory():


### PR DESCRIPTION
This adds pytest assertion logging of "actual vs expected" for code in the tests/helpers folder.

Without assert_rewrite:
        >           assert submission_id is not None
        E           AssertionError

With assert_rewrite:
        >           assert submission_id is not None
        E           assert None is not None