### PR TITLE
Added support for Windows

### DIFF
--- a/tcex/bin/lib.py
+++ b/tcex/bin/lib.py
@@ -112,8 +112,9 @@ class Lib(Bin):
 
     def _create_lib_latest(self):
         """Create the lib_latest symlink for App Builder."""
-        # TODO: Update this method to copy latest lib directory on Windows.
-        if platform.system() != 'Windows':
+        if platform.system() == 'Windows':
+            shutil.copytree('lib_{}'.format(self.latest_version),  self.static_lib_dir)
+        else:
             if os.path.islink(self.static_lib_dir):
                 os.unlink(self.static_lib_dir)
             os.symlink('lib_{}'.format(self.latest_version), self.static_lib_dir)


### PR DESCRIPTION
Windows requires administrator or a specific local security policy to create a symlink. This commit copies the lib_3.X to lib_latest so that tclib and tcpackage work correctly for Windows.