### PR TITLE
Fixing "dictionary changed size during iteration" error

### DIFF
--- a/tcex/batch/batch.py
+++ b/tcex/batch/batch.py
@@ -569,7 +569,10 @@ class Batch:
         """
         data = []
         # process group objects
-        for xid in groups.keys():
+        # we are converting groups.keys() to a list because the data_group_association function
+        # will be deleting items the groups dictionary which would raise a
+        # "dictionary changed size during iteration" error
+        for xid in list(groups.keys()):
             # get association from group data
             assoc_group_data = self.data_group_association(xid)
             data += assoc_group_data


### PR DESCRIPTION
Fixing an error I found when trying to create groups via batch:

```
File "/misp_2_tc.py", line 616, in create_bae_data_in_tc
    batch_result_list = batch_job.submit_all(halt_on_error=False)
...
File "lib_3.6.5/tcex/batch/batch.py", line 572, in data_groups
    for xid in groups.keys():
RuntimeError: dictionary changed size during iteration
```