### PR TITLE
Adding dump.rdb to the gitignore used for creating new apps

### DIFF
--- a/app_init/gitignore
+++ b/app_init/gitignore
@@ -56,6 +56,7 @@ junit.xml
 py36.xml
 py37.xml
 py38.xml
+dump.rdb
 
 #-------------------------------------------------
 # Other Nonsense


### PR DESCRIPTION
The dump.rdb is created when using redis locally to test playbook apps. I think it would be helpful to add this to the .gitignore (and I don't see any downside or danger in doing so).