### PR TITLE
Adding args.py file to the services api template

### DIFF
--- a/app_init/service_api/args.py
+++ b/app_init/service_api/args.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Playbook Args"""
+
+
+class Args:
+    """Playbook Args"""
+
+    def __init__(self, parser):
+        """Initialize class properties."""


### PR DESCRIPTION
I've added an args.py to the services api template (otherwise the `tcinit --template service_api` command fails).