### PR TITLE
Fixing the creation of the 'kvstore' in staged data

### DIFF
--- a/tcex/profile/migrate.py
+++ b/tcex/profile/migrate.py
@@ -229,7 +229,7 @@ class Migrate:
         if 'stage' not in profile_data.keys():
             profile_data['stage'] = {'kvstore': {}}
         if 'kvstore' not in profile_data.get('stage').keys():
-            profile_data['stage']['kvstore'] = []
+            profile_data['stage']['kvstore'] = {}
 
     def stage_inputs(self, profile_data):
         """Stage any non-staged profile data."""


### PR DESCRIPTION
I _think_ that the value of the `kvstore` key in the staged data should be a dict by default. As it currently is implemented (with a list for the default value), it can produce this error if a test has a `['stage']` key, but a not a `['stage']['kvstore']` key:

```
TypeError: list indices must be integers or slices, not str
```