### PR TITLE
Fix missing app_lib.py for external_ingress template

### DIFF
--- a/tcex/app_config_object/templates.py
+++ b/tcex/app_config_object/templates.py
@@ -292,7 +292,7 @@ class DownloadTemplates(TemplateBase):
             overwrite='prompt',
             default_choice='no',
         )
-        if template and not template.startswith('external'):
+        if template:
             self.download_file(f'{self.url}/app_lib.py', destination='app_lib.py', overwrite=True)
             self.download_file(
                 f'{self.url}/{template}/args.py',


### PR DESCRIPTION
This change to app_config_object allows the external_ingress template to work correctly.