### PR TITLE
Updated templates.py to include app_lib.py for external_ingress template

### DIFF
--- a/tcex/app_config_object/templates.py
+++ b/tcex/app_config_object/templates.py
@@ -313,7 +313,6 @@ class DownloadTemplates(TemplateBase):
             overwrite='prompt',
             default_choice='no',
         )
-        self.download_file(url=f'{self.url}/app_lib.py', destination='app_lib.py', overwrite=True)
         self.download_file(
             f'{self.url}/app_lib.py',
             destination='app_lib.py',

--- a/tcex/app_config_object/templates.py
+++ b/tcex/app_config_object/templates.py
@@ -313,8 +313,14 @@ class DownloadTemplates(TemplateBase):
             overwrite='prompt',
             default_choice='no',
         )
+        self.download_file(url=f'{self.url}/app_lib.py', destination='app_lib.py', overwrite=True)
+        self.download_file(
+            f'{self.url}/app_lib.py',
+            destination='app_lib.py',
+            overwrite='prompt',
+            default_choice='no',
+        )
         if template and not template.startswith('external'):
-            self.download_file(f'{self.url}/app_lib.py', destination='app_lib.py', overwrite=True)
             self.download_file(
                 f'{self.url}/{template}/args.py',
                 destination='args.py',


### PR DESCRIPTION
Old version contain app_lib as an exclusion for external_ templates.
app_lib is referenced in run.py so it is necessary to include it.