### PR TITLE
Add size parameter to DataStore search examples

### DIFF
--- a/docs/_sources/module_datastore.rst.txt
+++ b/docs/_sources/module_datastore.rst.txt
@@ -69,7 +69,7 @@ The ``get()`` method also allows a search to be performed.
     :lineno-start: 1
 
     ds = self.tcex.datastore('local', 'myNumbers')
-    search = {'query': {'match_all': {}}}
+    search = {'size': 100, 'query': {'match_all': {}}}
     response = ds.get(rid='_search', data=search)
 
 

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -858,7 +858,7 @@
 <div class="section" id="search">
 <h4>Search<a class="headerlink" href="#search" title="Permalink to this headline">¶</a></h4>
 <div class="highlight-python notranslate"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">1</span>
-<span class="normal">2</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><span class="n">search</span> <span class="o">=</span> <span class="p">{</span><span class="s2">&quot;query&quot;</span><span class="p">:</span> <span class="p">{</span><span class="s2">&quot;match_all&quot;</span><span class="p">:</span> <span class="p">{}}}</span>
+<span class="normal">2</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><span class="n">search</span> <span class="o">=</span> <span class="p">{</span><span class="s2">&quot;size&quot;</span><span class="p">:</span> <span class="s2">100</span><span class="p">,</span> <span class="s2">&quot;query&quot;</span><span class="p">:</span> <span class="p">{</span><span class="s2">&quot;match_all&quot;</span><span class="p">:</span> <span class="p">{}}}</span>
 <span class="n">response</span> <span class="o">=</span> <span class="n">ds</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">rid</span><span class="o">=</span><span class="s2">&quot;_search&quot;</span><span class="p">,</span> <span class="n">data</span><span class="o">=</span><span class="n">search</span><span class="p">)</span>
 </pre></div>
 </td></tr></table></div>

--- a/docs/module_datastore.html
+++ b/docs/module_datastore.html
@@ -248,7 +248,7 @@
 <div class="highlight-python notranslate"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">1</span>
 <span class="normal">2</span>
 <span class="normal">3</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><span class="n">ds</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">tcex</span><span class="o">.</span><span class="n">datastore</span><span class="p">(</span><span class="s1">&#39;local&#39;</span><span class="p">,</span> <span class="s1">&#39;myNumbers&#39;</span><span class="p">)</span>
-<span class="n">search</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;query&#39;</span><span class="p">:</span> <span class="p">{</span><span class="s1">&#39;match_all&#39;</span><span class="p">:</span> <span class="p">{}}}</span>
+<span class="n">search</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;size&#39;</span><span class="p">:</span> <span class="s1">100</span><span class="p">,</span> <span class="s1">&#39;query&#39;</span><span class="p">:</span> <span class="p">{</span><span class="s1">&#39;match_all&#39;</span><span class="p">:</span> <span class="p">{}}}</span>
 <span class="n">response</span> <span class="o">=</span> <span class="n">ds</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">rid</span><span class="o">=</span><span class="s1">&#39;_search&#39;</span><span class="p">,</span> <span class="n">data</span><span class="o">=</span><span class="n">search</span><span class="p">)</span>
 </pre></div>
 </td></tr></table></div>

--- a/docs/src/module_datastore.rst
+++ b/docs/src/module_datastore.rst
@@ -69,7 +69,7 @@ The ``get()`` method also allows a search to be performed.
     :lineno-start: 1
 
     ds = self.tcex.datastore('local', 'myNumbers')
-    search = {'query': {'match_all': {}}}
+    search = {'size': 100, 'query': {'match_all': {}}}
     response = ds.get(rid='_search', data=search)
 
 

--- a/docs/src/snippets.inc
+++ b/docs/src/snippets.inc
@@ -407,7 +407,7 @@ Search
     :linenos:
     :lineno-start: 1
 
-    search = {"query": {"match_all": {}}}
+    search = {"size": 100, "query": {"match_all": {}}}
     response = ds.get(rid="_search", data=search)
 
 

--- a/docs/src/snippets.tsv
+++ b/docs/src/snippets.tsv
@@ -31,7 +31,7 @@ DataStore	Add	response = ds.add(rid="one", data={"one": 1})\n
 DataStore	Add (dynamic id)	response = ds.add(rid=None, data={"one": 1})\n
 DataStore	Put	response = ds.put(rid="one", data={"one": 1})\n
 DataStore	Delete	response = ds.delete(rid="one")\n
-DataStore	Search	search = {"query": {"match_all": {}}}\nresponse = ds.get(rid="_search", data=search)\n
+DataStore	Search	search = {"size": 100, "query": {"match_all": {}}}\nresponse = ds.get(rid="_search", data=search)\n
 Exit	Set exit message	self.exit_message = f"Created {indicator_count} indicators."\n
 Exit	Set exit code	# set the exit code and allow App to continue to process\nself.tcex.playbook.exit_code = 1\n
 Exit	Exit with error	# exit the App immediately with the provided exit message\nself.tcex.playbook.exit(code=1, msg="Failed to add indicators to Owner.")\n


### PR DESCRIPTION
For users not familiar with Elastic Search it can be very confusing when a search of the DataStore only returns 10 results. I've added the "size" parameter to all search examples.