### PR TITLE
Ensure batch objects are closed properly within tests

### DIFF
--- a/tcex/api/tc/v2/batch/batch.py
+++ b/tcex/api/tc/v2/batch/batch.py
@@ -928,11 +928,10 @@ class Batch(BatchWriter, BatchSubmit):
                     self.debug_path_files,
                     f'''{api_branch}--{xid}--{content_data.get('fileName').replace('/', ':')}''',
                 )
-                if os.path.isdir(os.path.dirname(fqfn)):
-                    with open(fqfn, 'wb') as fh:
-                        if not isinstance(content, bytes):
-                            content = content.encode()
-                        fh.write(content)
+                with open(fqfn, 'wb') as fh:
+                    if not isinstance(content, bytes):
+                        content = content.encode()
+                    fh.write(content)
 
             # Post File
             url = f'/v2/groups/{api_branch}/{xid}/upload'

--- a/tests/api/tc/v2/batch/test_attributes_1.py
+++ b/tests/api/tc/v2/batch/test_attributes_1.py
@@ -50,6 +50,7 @@ class TestAttributes:
         # submit batch
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 

--- a/tests/api/tc/v2/batch/test_group_interface_1.py
+++ b/tests/api/tc/v2/batch/test_group_interface_1.py
@@ -36,6 +36,7 @@ class TestGroup1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -58,6 +59,7 @@ class TestGroup1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -81,6 +83,7 @@ class TestGroup1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -105,6 +108,7 @@ class TestGroup1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -129,6 +133,7 @@ class TestGroup1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -152,6 +157,7 @@ class TestGroup1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -174,6 +180,7 @@ class TestGroup1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -196,6 +203,7 @@ class TestGroup1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -219,6 +227,7 @@ class TestGroup1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -243,6 +252,7 @@ class TestGroup1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -265,5 +275,6 @@ class TestGroup1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1

--- a/tests/api/tc/v2/batch/test_group_interface_2.py
+++ b/tests/api/tc/v2/batch/test_group_interface_2.py
@@ -36,6 +36,7 @@ class TestGroup2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -58,6 +59,7 @@ class TestGroup2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -81,6 +83,7 @@ class TestGroup2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -105,6 +108,7 @@ class TestGroup2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -134,6 +138,7 @@ class TestGroup2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -157,6 +162,7 @@ class TestGroup2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -179,6 +185,7 @@ class TestGroup2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -201,6 +208,7 @@ class TestGroup2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -230,6 +238,7 @@ class TestGroup2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -259,6 +268,7 @@ class TestGroup2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -281,5 +291,6 @@ class TestGroup2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1

--- a/tests/api/tc/v2/batch/test_group_interface_3.py
+++ b/tests/api/tc/v2/batch/test_group_interface_3.py
@@ -44,6 +44,7 @@ class TestGroup3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -74,6 +75,7 @@ class TestGroup3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -106,6 +108,7 @@ class TestGroup3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -140,6 +143,7 @@ class TestGroup3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -173,6 +177,7 @@ class TestGroup3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -203,6 +208,7 @@ class TestGroup3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -233,6 +239,7 @@ class TestGroup3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -263,6 +270,7 @@ class TestGroup3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -295,6 +303,7 @@ class TestGroup3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -328,6 +337,7 @@ class TestGroup3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -358,5 +368,6 @@ class TestGroup3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1

--- a/tests/api/tc/v2/batch/test_indicator_interface_1.py
+++ b/tests/api/tc/v2/batch/test_indicator_interface_1.py
@@ -36,6 +36,7 @@ class TestIndicator1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -58,6 +59,7 @@ class TestIndicator1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -87,6 +89,7 @@ class TestIndicator1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -109,6 +112,7 @@ class TestIndicator1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -131,5 +135,6 @@ class TestIndicator1:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1

--- a/tests/api/tc/v2/batch/test_indicator_interface_2.py
+++ b/tests/api/tc/v2/batch/test_indicator_interface_2.py
@@ -38,6 +38,7 @@ class TestIndicator2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -66,6 +67,7 @@ class TestIndicator2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -94,6 +96,7 @@ class TestIndicator2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -118,6 +121,7 @@ class TestIndicator2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -142,5 +146,6 @@ class TestIndicator2:
         ti.tag(name=tag)
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1

--- a/tests/api/tc/v2/batch/test_indicator_interface_3.py
+++ b/tests/api/tc/v2/batch/test_indicator_interface_3.py
@@ -46,6 +46,7 @@ class TestIndicator3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -78,6 +79,7 @@ class TestIndicator3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -110,6 +112,7 @@ class TestIndicator3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -142,6 +145,7 @@ class TestIndicator3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 
@@ -174,5 +178,6 @@ class TestIndicator3:
         )
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1

--- a/tests/api/tc/v2/batch/test_security_labels_1.py
+++ b/tests/api/tc/v2/batch/test_security_labels_1.py
@@ -42,5 +42,6 @@ class TestTags1:
         # submit batch
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1

--- a/tests/api/tc/v2/batch/test_tags_1.py
+++ b/tests/api/tc/v2/batch/test_tags_1.py
@@ -32,6 +32,7 @@ class TestTags1:
         # submit batch
         batch.save(ti)
         batch_status = batch.submit_all()
+        batch.close()
         assert batch_status[0].get('status') == 'Completed'
         assert batch_status[0].get('successCount') == 1
 


### PR DESCRIPTION
Ensure that batch.close() is called on batch objects within tests, which allows for consistent test execution.