### PR TITLE
Add Customizable Choice and EditChoice fields

### DIFF
--- a/tcex/input/field_types/__init__.py
+++ b/tcex/input/field_types/__init__.py
@@ -3,9 +3,9 @@
 # flake8:noqa
 # first-party
 from tcex.input.field_types.binary import Binary, binary
-from tcex.input.field_types.choice import Choice
+from tcex.input.field_types.choice import Choice, choice
 from tcex.input.field_types.datetime import DateTime
-from tcex.input.field_types.edit_choice import EditChoice
+from tcex.input.field_types.edit_choice import EditChoice, edit_choice
 from tcex.input.field_types.group_entity import GroupEntity
 from tcex.input.field_types.indicator_entity import (
     AddressEntity,

--- a/tcex/input/field_types/choice.py
+++ b/tcex/input/field_types/choice.py
@@ -42,5 +42,11 @@ def choice(value_transformations: Optional[Dict[str, str]] = None) -> type:
     If this field were to be initialized with 'my_choice', then the final value found in the input
     model would be 'My Choice'.
     """
+    if not isinstance(value_transformations, (dict, type(None))):
+        raise ValueError(
+            '"value_transformations" customization expects a dictionary value. Received: '
+            f'{type(value_transformations)}'
+        )
+
     namespace = dict(_value_transformations=value_transformations)
     return type('CustomChoice', (Choice,), namespace)

--- a/tcex/input/field_types/choice.py
+++ b/tcex/input/field_types/choice.py
@@ -32,6 +32,15 @@ class Choice(EditChoice):
 
 
 def choice(value_transformations: Optional[Dict[str, str]] = None) -> type:
-    """Return configured instance of String."""
+    """Return configured instance of String.
+
+    :param value_transformations: dictionary that dictates how a choice should be transformed.
+    Dictionary keys should be the field's valid values as defined in the install.json. Example:
+
+    value_transformations: {'my_choice': 'My Choice'}
+
+    If this field were to be initialized with 'my_choice', then the final value found in the input
+    model would be 'My Choice'.
+    """
     namespace = dict(_value_transformations=value_transformations)
     return type('CustomChoice', (Choice,), namespace)

--- a/tcex/input/field_types/choice.py
+++ b/tcex/input/field_types/choice.py
@@ -1,6 +1,6 @@
 """Choice Field Type"""
 # standard library
-from typing import Callable
+from typing import Callable, Dict, Optional
 
 # first-party
 from tcex.input.field_types.edit_choice import EditChoice
@@ -29,3 +29,9 @@ class Choice(EditChoice):
             value = None
 
         return value
+
+
+def choice(value_transformations: Optional[Dict[str, str]] = None) -> type:
+    """Return configured instance of String."""
+    namespace = dict(_value_transformations=value_transformations)
+    return type('CustomChoice', (Choice,), namespace)

--- a/tcex/input/field_types/choice.py
+++ b/tcex/input/field_types/choice.py
@@ -42,11 +42,5 @@ def choice(value_transformations: Optional[Dict[str, str]] = None) -> type:
     If this field were to be initialized with 'my_choice', then the final value found in the input
     model would be 'My Choice'.
     """
-    if not isinstance(value_transformations, (dict, type(None))):
-        raise ValueError(
-            '"value_transformations" customization expects a dictionary value. Received: '
-            f'{type(value_transformations)}'
-        )
-
     namespace = dict(_value_transformations=value_transformations)
     return type('CustomChoice', (Choice,), namespace)

--- a/tcex/input/field_types/edit_choice.py
+++ b/tcex/input/field_types/edit_choice.py
@@ -59,7 +59,7 @@ class EditChoice(str):
                 value = vv
                 break
         else:
-            if not cls._allow_additional:
+            if cls._allow_additional is False:
                 raise InvalidInput(
                     field_name=field.name,
                     error=f'provided value {value} is not a valid value {_valid_values}',
@@ -86,6 +86,18 @@ def edit_choice(
     If this field were to be initialized with 'my_choice', then the final value found in the input
     model would be 'My Choice'.
     """
+    if not isinstance(allow_additional, bool):
+        raise ValueError(
+            '"allow_additional" customization expects a boolean value. Received: '
+            f'{type(allow_additional)}'
+        )
+
+    if not isinstance(value_transformations, (dict, type(None))):
+        raise ValueError(
+            '"value_transformations" customization expects a dictionary value. Received: '
+            f'{type(value_transformations)}'
+        )
+
     namespace = dict(
         _value_transformations=value_transformations,
         _allow_additional=allow_additional,

--- a/tcex/input/field_types/edit_choice.py
+++ b/tcex/input/field_types/edit_choice.py
@@ -86,18 +86,6 @@ def edit_choice(
     If this field were to be initialized with 'my_choice', then the final value found in the input
     model would be 'My Choice'.
     """
-    if not isinstance(allow_additional, bool):
-        raise ValueError(
-            '"allow_additional" customization expects a boolean value. Received: '
-            f'{type(allow_additional)}'
-        )
-
-    if not isinstance(value_transformations, (dict, type(None))):
-        raise ValueError(
-            '"value_transformations" customization expects a dictionary value. Received: '
-            f'{type(value_transformations)}'
-        )
-
     namespace = dict(
         _value_transformations=value_transformations,
         _allow_additional=allow_additional,

--- a/tcex/input/field_types/edit_choice.py
+++ b/tcex/input/field_types/edit_choice.py
@@ -1,10 +1,10 @@
 """Valid Values Field Type"""
 # standard library
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Dict, Optional
 
 # first-party
 from tcex.app_config.install_json import InstallJson
-from tcex.input.field_types.exception import InvalidInput, InvalidType
+from tcex.input.field_types.exception import InvalidEmptyValue, InvalidInput, InvalidType
 
 if TYPE_CHECKING:  # pragma: no cover
     # third-party
@@ -21,6 +21,9 @@ class EditChoice(str):
     * Magic Variables (e.g. ${OWNERS})
     * EditChoice (dynamic values supported)
     """
+
+    _allow_additional = False
+    _value_transformations = None
 
     @classmethod
     def __get_validators__(cls) -> Callable:
@@ -46,6 +49,9 @@ class EditChoice(str):
     @classmethod
     def validate_valid_values(cls, value: str, field: 'ModelField') -> str:
         """Raise exception if value is not a String type."""
+        if value == '':
+            raise InvalidEmptyValue(field.name)
+
         ij = InstallJson()
         _valid_values = ij.model.get_param(field.name).valid_values or []
         for vv in _valid_values:
@@ -53,8 +59,35 @@ class EditChoice(str):
                 value = vv
                 break
         else:
-            raise InvalidInput(
-                field_name=field.name,
-                error=f'provided value {value} is not a valid value {_valid_values}',
-            )
+            if not cls._allow_additional:
+                raise InvalidInput(
+                    field_name=field.name,
+                    error=f'provided value {value} is not a valid value {_valid_values}',
+                )
+
+        if isinstance(cls._value_transformations, dict):
+            value = cls._value_transformations.get(value, value)
+
         return value
+
+
+def edit_choice(
+    allow_additional: bool = False, value_transformations: Optional[Dict[str, str]] = None
+) -> type:
+    """Return configured instance of String.
+
+    :param allow_additional: Denotes whether this field will allow values that are not found in
+    the field's valid values list in the install.json.
+    :param value_transformations: dictionary that dictates how a choice should be transformed.
+    Dictionary keys should be the field's valid values as defined in the install.json. Example:
+
+    value_transformations: {'my_choice': 'My Choice'}
+
+    If this field were to be initialized with 'my_choice', then the final value found in the input
+    model would be 'My Choice'.
+    """
+    namespace = dict(
+        _value_transformations=value_transformations,
+        _allow_additional=allow_additional,
+    )
+    return type('CustomEditChoice', (EditChoice,), namespace)

--- a/tests/input/field_types/test_field_type_edit_choice.py
+++ b/tests/input/field_types/test_field_type_edit_choice.py
@@ -1,6 +1,6 @@
 """Testing TcEx Input module field types."""
 # standard library
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 # third-party
 import pytest
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 # first-party
 from tcex.backports import cached_property
-from tcex.input.field_types import EditChoice
+from tcex.input.field_types import EditChoice, edit_choice
 from tcex.pleb.scoped_property import scoped_property
 from tests.input.field_types.utils import InputTest
 
@@ -36,10 +36,10 @@ class TestInputsFieldTypes(InputTest):
             ('choice_1', 'choice_1', False, False),
             # optional, null input
             (None, None, True, False),
-            # #
+            #
             # Fail Testing
             #
-            # required, invalid input
+            # invalid choice
             ('invalid_choice', None, False, True),
             # required, empty input
             ('', '', False, True),
@@ -57,7 +57,7 @@ class TestInputsFieldTypes(InputTest):
         fail_test: bool,
         playbook_app: 'MockApp',
     ):
-        """Test Binary field type.
+        """Test EditChoice field type.
 
         Playbook Data Type: String
         Validation: Not null
@@ -76,6 +76,91 @@ class TestInputsFieldTypes(InputTest):
                 """Test Model for Inputs"""
 
                 my_choice: Optional[EditChoice]
+
+        self._type_validation(
+            PytestModel,
+            input_name='my_choice',
+            input_value=input_value,
+            input_type='String',
+            expected=expected,
+            fail_test=fail_test,
+            playbook_app=playbook_app,
+        )
+
+    @pytest.mark.parametrize(
+        'input_value,expected,optional,fail_test,transformations,allow_additional',
+        [
+            #
+            # Pass Testing
+            #
+            # required, normal input
+            ('choice_1', 'choice_1', False, False, None, False),
+            # optional, null input
+            (None, None, True, False, None, False),
+            # pass transformations dict, valid value should be transformed
+            ('choice_1', 'Choice 1', False, False, {'choice_1': 'Choice 1'}, False),
+            # pass transformations dict, value not transformed as it is not in transformations dict
+            ('choice_1', 'choice_1', False, False, {'choice_2': 'Choice 2'}, False),
+            #
+            # Transformations when field is Optional
+            # pass transformations dict, valid value should be transformed
+            ('choice_1', 'Choice 1', True, False, {'choice_1': 'Choice 1'}, False),
+            # pass transformations dict, value not transformed as it is not in transformations dict
+            ('choice_1', 'choice_1', True, False, {'choice_2': 'Choice 2'}, False),
+            #
+            # invalid choice allowed because of allow_additional=True
+            ('invalid_choice', 'invalid_choice', False, False, None, True),
+            # same as above but with optional field
+            ('invalid_choice', 'invalid_choice', True, False, None, True),
+            #
+            #
+            # Fail Testing
+            #
+            # invalid choice
+            ('invalid_choice', None, False, True, None, False),
+            # required, empty input
+            ('', '', False, True, None, False),
+            # optional, empty input
+            ('', '', True, True, None, False),
+            # required, null input
+            (None, None, False, True, None, False),
+        ],
+    )
+    def test_custom_edit_choice_type(
+        self,
+        input_value: str,
+        expected: str,
+        optional: bool,
+        fail_test: bool,
+        allow_additional: bool,
+        playbook_app: 'MockApp',
+        transformations: Dict,
+    ):
+        """Test Custom EditChoice field type.
+
+        Playbook Data Type: String
+        Validation: Not null
+        """
+
+        if optional is False:
+
+            class PytestModel(BaseModel):
+                """Test Model for Inputs"""
+
+                my_choice: edit_choice(
+                    value_transformations=transformations, allow_additional=allow_additional
+                )
+
+        else:
+
+            class PytestModel(BaseModel):
+                """Test Model for Inputs"""
+
+                my_choice: Optional[
+                    edit_choice(
+                        value_transformations=transformations, allow_additional=allow_additional
+                    )
+                ]
 
         self._type_validation(
             PytestModel,


### PR DESCRIPTION
- Adds customizable Choice and EditChoice fields
- Customizable Choice and EditChoice fields take `value_transformations` dictionary, which dictates how a choice should be transformed. Example:

    value_transformations: {'my_choice': 'My Choice'}

    If the field were to be initialized with 'my_choice', then the final value found in the input
    model would be 'My Choice'.
- Customizable EditChoice field takes `allow_additional` boolean, which denotes whether the field will allow values that are not found in the field's valid values list in the install.json