### PR TITLE
+ minor updates and fixes

### DIFF
--- a/tcex/app_config/models/install_json_model.py
+++ b/tcex/app_config/models/install_json_model.py
@@ -121,15 +121,15 @@ class FeedsModel(BaseModel):
     source_description: str = Field(
         ...,
         description=(
-            'Optional property that provides the source’s description as it will be '
-            'displayed in the ThreatConnect platform.'
+            '''Optional property that provides the source's description as it will be '''
+            '''displayed in the ThreatConnect platform.'''
         ),
     )
     source_name: str = Field(
         ...,
         description=(
-            'Optional property that provides the name of the source in which the feed’s '
-            'content will be created.'
+            '''Optional property that provides the name of the source in which the feed's '''
+            '''content will be created.'''
         ),
     )
 

--- a/tcex/app_config/models/job_json_model.py
+++ b/tcex/app_config/models/job_json_model.py
@@ -20,6 +20,7 @@ class ParamsModel(BaseModel):
     """Model for jj.params"""
 
     default: Optional[Union[bool, str]]
+    encrypt: Optional[bool] = False
     name: str
     prevent_updates: bool = False
 

--- a/tcex/bin/spec_tool.py
+++ b/tcex/bin/spec_tool.py
@@ -171,20 +171,24 @@ class SpecTool(BinABC):
             # check that app_spec.yml exists
             self._check_has_spec()
 
-            try:
-                lj = gen.generate()
-            except ValidationError as ex:
-                self.print_failure(f'Failed Generating layout.json:\n{ex}')
+            # only App with a "tc_action" input should have a layout.json file
+            if not [p for p in self.asy.model.params if p.name == 'tc_action']:
+                self.log.info('action=generate-layout-json, results=no-action-input')
+            else:
+                try:
+                    lj = gen.generate()
+                except ValidationError as ex:
+                    self.print_failure(f'Failed Generating layout.json:\n{ex}')
 
-            config = lj.json(
-                by_alias=True,
-                exclude_defaults=False,
-                exclude_none=True,
-                exclude_unset=True,
-                indent=2,
-                sort_keys=True,
-            )
-            self.write_app_file(gen.filename, f'{config}\n')
+                config = lj.json(
+                    by_alias=True,
+                    exclude_defaults=False,
+                    exclude_none=True,
+                    exclude_unset=True,
+                    indent=2,
+                    sort_keys=True,
+                )
+                self.write_app_file(gen.filename, f'{config}\n')
 
     def generate_job_json(self, schema: bool) -> None:
         """Generate the job.json file."""

--- a/tcex/bin/spec_tool_job_json.py
+++ b/tcex/bin/spec_tool_job_json.py
@@ -29,7 +29,13 @@ class SpecToolJobJson(BinABC):
             for feed in self.asy.model.organization.feeds:
                 _job_data = feed.job.dict(by_alias=True)
                 app_name = self.tj.model.package.app_name.replace('_', ' ')
-                _job_data['programName'] = f'{app_name} v{self.asy.model.program_version.major}'
+
+                # handle statically defined version in tcex.json file
+                version = f'v{self.asy.model.program_version.major}'
+                if self.tj.model.package.app_version:
+                    version = self.tj.model.package.app_version
+
+                _job_data['programName'] = f'{app_name} {version}'
                 _job_data['programVersion'] = str(self.asy.model.program_version)
                 yield feed.job_file, JobJsonModel(**_job_data)
 


### PR DESCRIPTION
- added encrypt to param fields in the job json model
- added support for hard code version number in job json (for legacy Apps)
- updated spectool to not generate layout.json if not "tc_action" field exists as input
- fixed issue in Choice field type where validation wasn't working properly