### PR TITLE
APP-3470 don't add empty strings to senstiive filter

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,7 +4,7 @@
 
 - APP-3468 - [Pleb] Fix ScopedProperty for multiprocess use.
 - APP-3470 - [Sensitive] Don't add empty strings to the sensitive filter.
- 
+
 ### 3.0.1
 
 -   APP-3432 - [CLI] Fixed issue where numeric values are getting stripped from input name during validation

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,7 +3,8 @@
 ### 3.0.2
 
 - APP-3468 - [Pleb] Fix ScopedProperty for multiprocess use.
-
+- APP-3470 - [Sensitive] Don't add empty strings to the sensitive filter.
+ 
 ### 3.0.1
 
 -   APP-3432 - [CLI] Fixed issue where numeric values are getting stripped from input name during validation

--- a/tcex/input/field_types/sensitive.py
+++ b/tcex/input/field_types/sensitive.py
@@ -34,6 +34,7 @@ class Sensitive:
             self._sensitive_value = value.value
         else:
             self._sensitive_value = value
+        filter_sensitive.add(self._sensitive_value)
 
     @classmethod
     def __get_validators__(cls) -> Callable:

--- a/tcex/input/field_types/sensitive.py
+++ b/tcex/input/field_types/sensitive.py
@@ -34,7 +34,8 @@ class Sensitive:
             self._sensitive_value = value.value
         else:
             self._sensitive_value = value
-        filter_sensitive.add(self._sensitive_value)
+        if self._sensitive_value:
+            filter_sensitive.add(self._sensitive_value)
 
     @classmethod
     def __get_validators__(cls) -> Callable:

--- a/tcex/input/field_types/sensitive.py
+++ b/tcex/input/field_types/sensitive.py
@@ -34,8 +34,6 @@ class Sensitive:
             self._sensitive_value = value.value
         else:
             self._sensitive_value = value
-        if self._sensitive_value:
-            filter_sensitive.add(self._sensitive_value)
 
     @classmethod
     def __get_validators__(cls) -> Callable:

--- a/tcex/logger/sensitive_filter.py
+++ b/tcex/logger/sensitive_filter.py
@@ -13,7 +13,9 @@ class SensitiveFilter(logging.Filter):
 
     def add(self, value: str) -> None:
         """Add sensitive value to registry."""
-        self._sensitive_registry.add(str(value))
+        if value:
+            # don't add empty string
+            self._sensitive_registry.add(str(value))
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Filter the record"""


### PR DESCRIPTION
If an empty string is added to senstivie filter, every character in the log is bracketed by “***”s