### PR TITLE
Fix error when running tcex commands

### DIFF
--- a/bin/tcex
+++ b/bin/tcex
@@ -24,7 +24,7 @@ def deps(
         'main',
         help=(
             'The git branch of the tcex repository to use. '
-            'This override what is in the requirements.txt file.',
+            'This override what is in the requirements.txt file.'
         ),
     ),
     dev: Optional[bool] = typer.Option(False, help='Install development dependencies.'),


### PR DESCRIPTION
Fix error (AttributeError: 'tuple' object has no attribute 'expandtabs') caused by typo. There is an extra dangling comma (,) which resulted in a tuple being created instead of a string and caused error in subsequent function expecting a string.