### PR TITLE
spectool updates; typing hint cleanup

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -52,6 +52,7 @@ loadscope
 maxkb
 mitmproxy
 mqtt
+multichoice
 nargs
 newstr
 paco

--- a/tcex/api/tc/utils/threat_intel_utils.py
+++ b/tcex/api/tc/utils/threat_intel_utils.py
@@ -23,7 +23,7 @@ class ThreatIntelUtils:
     INDICATOR = 'Indicator'
     GROUP = 'Group'
 
-    def __init__(self, session_tc: Session) -> None:
+    def __init__(self, session_tc: Session):
         """Initialize class properties."""
         self.session_tc = session_tc
 
@@ -57,7 +57,7 @@ class ThreatIntelUtils:
             },
         }
 
-    def _association_types(self) -> None:
+    def _association_types(self):
         """Retrieve Custom Indicator Associations types from the ThreatConnect API."""
 
     @staticmethod

--- a/tcex/api/tc/v2/batch/attribute.py
+++ b/tcex/api/tc/v2/batch/attribute.py
@@ -16,7 +16,7 @@ class Attribute:
         displayed: Optional[bool] = False,
         source: Optional[str] = None,
         formatter: Optional[Callable[[str], str]] = None,
-    ) -> None:
+    ):
         """Initialize Class Properties.
 
         Args:
@@ -88,5 +88,5 @@ class Attribute:
         return self._attribute_data.get('value')
 
     def __str__(self) -> str:
-        """Return string represtentation of object."""
+        """Return string representation of object."""
         return json.dumps(self.data, indent=4)

--- a/tcex/api/tc/v2/batch/batch.py
+++ b/tcex/api/tc/v2/batch/batch.py
@@ -15,11 +15,12 @@ from requests import Response, Session
 
 # first-party
 from tcex.api.tc.v2.batch.batch_submit import BatchSubmit
-from tcex.api.tc.v2.batch.batch_writer import BatchWriter, GroupType, IndicatorType
+from tcex.api.tc.v2.batch.batch_writer import BatchWriter
 from tcex.exit.error_codes import handle_error
 
 if TYPE_CHECKING:
     # first-party
+    from tcex.api.tc.v2.batch.batch_writer import GroupType, IndicatorType
     from tcex.input import Input
 
 
@@ -49,7 +50,7 @@ class Batch(BatchWriter, BatchSubmit):
         playbook_triggers_enabled: Optional[bool] = False,
         tag_write_type: Optional[str] = 'Replace',
         security_label_write_type: Optional[str] = 'Replace',
-    ) -> None:
+    ):
         """Initialize Class properties."""
         BatchWriter.__init__(self, inputs=inputs, session_tc=session_tc, output_dir='')
         BatchSubmit.__init__(
@@ -108,8 +109,8 @@ class Batch(BatchWriter, BatchSubmit):
         self.debug_path_xids = os.path.join(self.debug_path, 'xids-saved')
 
     def _group(
-        self, group_data: Union[dict, GroupType], store: Optional[bool] = True
-    ) -> Union[dict, GroupType]:
+        self, group_data: Union[dict, 'GroupType'], store: Optional[bool] = True
+    ) -> Union[dict, 'GroupType']:
         """Return previously stored group or new group.
 
         Args:
@@ -141,8 +142,8 @@ class Batch(BatchWriter, BatchSubmit):
         return group_data
 
     def _indicator(
-        self, indicator_data: Union[dict, IndicatorType], store: Optional[bool] = True
-    ) -> Union[dict, IndicatorType]:
+        self, indicator_data: Union[dict, 'IndicatorType'], store: Optional[bool] = True
+    ) -> Union[dict, 'IndicatorType']:
         """Return previously stored indicator or new indicator.
 
         Args:
@@ -170,7 +171,7 @@ class Batch(BatchWriter, BatchSubmit):
             self.indicators[xid] = indicator_data
         return indicator_data
 
-    def close(self) -> None:
+    def close(self):
         """Cleanup batch job."""
         # allow pol thread to complete before wrapping up
         if hasattr(self._submit_thread, 'is_alive'):
@@ -225,7 +226,7 @@ class Batch(BatchWriter, BatchSubmit):
 
         return data
 
-    def data_group_association(self, data: dict, tracker: dict, xid: str) -> None:
+    def data_group_association(self, data: dict, tracker: dict, xid: str):
         """Return group dict array following all associations.
 
         The *data* dict is passed by reference to make it easier to update both the group data
@@ -265,7 +266,7 @@ class Batch(BatchWriter, BatchSubmit):
                 xids.extend(group_data.get('associatedGroupXid', []))
 
     @staticmethod
-    def data_group_type(group_data: Union[dict, GroupType]) -> Tuple[dict, dict]:
+    def data_group_type(group_data: Union[dict, 'GroupType']) -> Tuple[dict, dict]:
         """Return dict representation of group data and file data.
 
         Args:
@@ -406,7 +407,7 @@ class Batch(BatchWriter, BatchSubmit):
         if isinstance(value, bool):
             self._halt_on_file_error = value
 
-    def process_all(self, process_files: Optional[bool] = True) -> None:
+    def process_all(self, process_files: Optional[bool] = True):
         """Process Batch request to ThreatConnect API.
 
         Args:
@@ -434,7 +435,7 @@ class Batch(BatchWriter, BatchSubmit):
         if process_files:
             self.process_files(file_data)
 
-    def process_files(self, file_data: dict) -> None:
+    def process_files(self, file_data: dict):
         """Process Files for Documents and Reports to ThreatConnect API.
 
         Args:
@@ -782,7 +783,7 @@ class Batch(BatchWriter, BatchSubmit):
         callback: Callable[..., Any],
         file_data: dict,
         halt_on_error: Optional[bool] = True,
-    ) -> None:
+    ):
         """Submit data in a thread."""
         batch_id = batch_data.get('id')
         self.log.info(f'feature=batch, event=progress, batch-id={batch_id}')
@@ -1031,7 +1032,7 @@ class Batch(BatchWriter, BatchSubmit):
         target: Callable[[], bool],
         args: Optional[tuple] = None,
         kwargs: Optional[dict] = None,
-    ) -> None:
+    ):
         """Start a submit thread.
 
         Args:
@@ -1050,7 +1051,7 @@ class Batch(BatchWriter, BatchSubmit):
             self.log.trace(traceback.format_exc())
         return t
 
-    def write_error_json(self, errors: list) -> None:
+    def write_error_json(self, errors: list):
         """Write the errors to a JSON file for debugging purposes.
 
         Args:
@@ -1065,7 +1066,7 @@ class Batch(BatchWriter, BatchSubmit):
             with gzip.open(error_json_file, mode='wt', encoding='utf-8') as fh:
                 json.dump(errors, fh)
 
-    def write_batch_json(self, content: dict) -> None:
+    def write_batch_json(self, content: dict):
         """Write batch json data to a file."""
         if self.debug and content:
             # get timestamp as a string without decimal place and consistent length

--- a/tcex/api/tc/v2/batch/batch_submit.py
+++ b/tcex/api/tc/v2/batch/batch_submit.py
@@ -33,7 +33,7 @@ class BatchSubmit:
         playbook_triggers_enabled: Optional[bool] = False,
         tag_write_type: Optional[str] = 'Replace',
         security_label_write_type: Optional[str] = 'Replace',
-    ) -> None:
+    ):
         """Initialize Class properties.
 
         Args:
@@ -86,7 +86,7 @@ class BatchSubmit:
         return self._action
 
     @action.setter
-    def action(self, action) -> None:
+    def action(self, action):
         """Set batch action."""
         self._action = action
 
@@ -96,7 +96,7 @@ class BatchSubmit:
         return self._attribute_write_type
 
     @attribute_write_type.setter
-    def attribute_write_type(self, write_type: str) -> None:
+    def attribute_write_type(self, write_type: str):
         """Set batch attribute write type."""
         self._attribute_write_type = write_type
 
@@ -199,7 +199,7 @@ class BatchSubmit:
 
         return errors
 
-    def file_merge_mode(self, value: str) -> None:
+    def file_merge_mode(self, value: str):
         """Set the file merge mode for the entire batch job.
 
         Args:
@@ -213,7 +213,7 @@ class BatchSubmit:
         return self._halt_on_error
 
     @halt_on_error.setter
-    def halt_on_error(self, halt_on_error: bool) -> None:
+    def halt_on_error(self, halt_on_error: bool):
         """Set batch halt on error setting."""
         self._halt_on_error = halt_on_error
 
@@ -223,7 +223,7 @@ class BatchSubmit:
         return self._halt_on_batch_error
 
     @halt_on_batch_error.setter
-    def halt_on_batch_error(self, value: bool) -> None:
+    def halt_on_batch_error(self, value: bool):
         """Set batch halt on batch error value."""
         if isinstance(value, bool):
             self._halt_on_batch_error = value
@@ -234,7 +234,7 @@ class BatchSubmit:
         return self._halt_on_poll_error
 
     @halt_on_poll_error.setter
-    def halt_on_poll_error(self, value: bool) -> None:
+    def halt_on_poll_error(self, value: bool):
         """Set batch halt on poll error value."""
         if isinstance(value, bool):
             self._halt_on_poll_error = value
@@ -379,7 +379,7 @@ class BatchSubmit:
         return self._poll_timeout
 
     @poll_timeout.setter
-    def poll_timeout(self, seconds: int) -> None:
+    def poll_timeout(self, seconds: int):
         """Set the poll timeout value."""
         self._poll_timeout = int(seconds)
 
@@ -389,7 +389,7 @@ class BatchSubmit:
         return self._security_label_write_type
 
     @security_label_write_type.setter
-    def security_label_write_type(self, write_type: str) -> None:
+    def security_label_write_type(self, write_type: str):
         """Set batch security label write type."""
         self._security_label_write_type = write_type
 
@@ -499,6 +499,6 @@ class BatchSubmit:
         return self._tag_write_type
 
     @tag_write_type.setter
-    def tag_write_type(self, write_type: str) -> None:
+    def tag_write_type(self, write_type: str):
         """Set batch tag write type."""
         self._tag_write_type = write_type

--- a/tcex/api/tc/v2/batch/batch_writer.py
+++ b/tcex/api/tc/v2/batch/batch_writer.py
@@ -11,10 +11,7 @@ import sys
 import time
 import uuid
 from collections import deque
-from typing import Optional, Tuple, Union
-
-# third-party
-from requests import Session
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 # first-party
 from tcex.api.tc.utils.threat_intel_utils import ThreatIntelUtils
@@ -51,8 +48,14 @@ from tcex.api.tc.v2.batch.indicator import (
     UserAgent,
     custom_indicator_class_factory,
 )
-from tcex.input.input import Input
 from tcex.utils import Utils
+
+if TYPE_CHECKING:
+    # third-party
+    from requests import Session
+
+    # first-party
+    from tcex.input.input import Input
 
 # import local modules for dynamic reference
 module = __import__(__name__)
@@ -106,7 +109,7 @@ class BatchWriter:
         output_dir: The directory to write the batch JSON data.
     """
 
-    def __init__(self, inputs: Input, session_tc: Session, output_dir: str, **kwargs) -> None:
+    def __init__(self, inputs: 'Input', session_tc: 'Session', output_dir: str, **kwargs):
         """Initialize Class properties."""
         self.inputs = inputs
         self.output_dir = output_dir
@@ -137,7 +140,7 @@ class BatchWriter:
         # build custom indicator classes
         self._gen_indicator_class()
 
-    def _gen_indicator_class(self) -> None:  # pragma: no cover
+    def _gen_indicator_class(self):  # pragma: no cover
         """Generate Custom Indicator Classes."""
         for entry in self.tic.indicator_types_data.values():
             name = entry.get('name')
@@ -168,8 +171,8 @@ class BatchWriter:
             self._gen_indicator_method(name, custom_class, value_count)
 
     def _gen_indicator_method(
-        self, name: str, custom_class: IndicatorType, value_count: int
-    ) -> None:  # pragma: no cover
+        self, name: str, custom_class: 'IndicatorType', value_count: int
+    ):  # pragma: no cover
         """Dynamically generate custom Indicator methods.
 
         Args:
@@ -203,8 +206,8 @@ class BatchWriter:
         setattr(self, method_name, method)
 
     def _group(
-        self, group_data: Union[dict, GroupType], store: Optional[bool] = True
-    ) -> Union[dict, GroupType]:
+        self, group_data: Union[dict, 'GroupType'], store: Optional[bool] = True
+    ) -> Union[dict, 'GroupType']:
         """Return previously stored group or new group.
 
         Args:
@@ -243,8 +246,8 @@ class BatchWriter:
         return group_data
 
     def _indicator(
-        self, indicator_data: Union[dict, IndicatorType], store: Optional[bool] = True
-    ) -> Union[dict, IndicatorType]:
+        self, indicator_data: Union[dict, 'IndicatorType'], store: Optional[bool] = True
+    ) -> Union[dict, 'IndicatorType']:
         """Return previously stored indicator or new indicator.
 
         Args:
@@ -315,7 +318,7 @@ class BatchWriter:
 
         return indicator_list
 
-    def add_group(self, group_data: dict, **kwargs) -> Union[dict, GroupType]:
+    def add_group(self, group_data: dict, **kwargs) -> Union[dict, 'GroupType']:
         """Add a group to Batch Job.
 
         .. code-block:: javascript
@@ -348,7 +351,7 @@ class BatchWriter:
         """
         return self._group(group_data, kwargs.get('store', True))
 
-    def add_indicator(self, indicator_data: dict, **kwargs) -> Union[dict, IndicatorType]:
+    def add_indicator(self, indicator_data: dict, **kwargs) -> Union[dict, 'IndicatorType']:
         """Add an indicator to Batch Job.
 
         .. code-block:: javascript
@@ -412,7 +415,7 @@ class BatchWriter:
                 indicator_data['flag2'] = whois_active
         return self._indicator(indicator_data, kwargs.get('store', True))
 
-    def address(self, ip: str, **kwargs) -> Address:
+    def address(self, ip: str, **kwargs) -> 'Address':
         """Add Address data to Batch.
 
         Args:
@@ -431,7 +434,7 @@ class BatchWriter:
         indicator_obj = Address(ip, **kwargs)
         return self._indicator(indicator_obj, kwargs.get('store', True))
 
-    def adversary(self, name: str, **kwargs) -> Adversary:
+    def adversary(self, name: str, **kwargs) -> 'Adversary':
         """Add Adversary data to Batch.
 
         Args:
@@ -447,7 +450,7 @@ class BatchWriter:
         group_obj = Adversary(name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def attack_pattern(self, name: str, **kwargs) -> AttackPattern:
+    def attack_pattern(self, name: str, **kwargs) -> 'AttackPattern':
         """Add Attack Pattern data to Batch object.
 
         Args:
@@ -463,7 +466,7 @@ class BatchWriter:
         group_obj = AttackPattern(name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def asn(self, as_number: str, **kwargs) -> ASN:
+    def asn(self, as_number: str, **kwargs) -> 'ASN':
         """Add ASN data to Batch.
 
         Args:
@@ -482,7 +485,7 @@ class BatchWriter:
         indicator_obj = ASN(as_number, **kwargs)
         return self._indicator(indicator_obj, kwargs.get('store', True))
 
-    def campaign(self, name: str, **kwargs) -> Campaign:
+    def campaign(self, name: str, **kwargs) -> 'Campaign':
         """Add Campaign data to Batch.
 
         Args:
@@ -499,7 +502,7 @@ class BatchWriter:
         group_obj = Campaign(name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def cidr(self, block: str, **kwargs) -> CIDR:
+    def cidr(self, block: str, **kwargs) -> 'CIDR':
         """Add CIDR data to Batch.
 
         Args:
@@ -518,7 +521,7 @@ class BatchWriter:
         indicator_obj = CIDR(block, **kwargs)
         return self._indicator(indicator_obj, kwargs.get('store', True))
 
-    def close(self) -> None:
+    def close(self):
         """Cleanup batch job."""
         self.dump()
 
@@ -538,7 +541,7 @@ class BatchWriter:
                 f'action=batch-close, filename={self.indicator_shelf_fqfn} exception={ex}'
             )
 
-    def course_of_action(self, name: str, **kwargs) -> CourseOfAction:
+    def course_of_action(self, name: str, **kwargs) -> 'CourseOfAction':
         """Add Course Of Action Pattern data to Batch object.
 
         Args:
@@ -590,7 +593,7 @@ class BatchWriter:
 
         return data
 
-    def data_group_association(self, data: dict, tracker: dict, xid: str) -> None:
+    def data_group_association(self, data: dict, tracker: dict, xid: str):
         """Return group dict array following all associations.
 
         The *data* dict is passed by reference to make it easier to update both the group data
@@ -628,7 +631,7 @@ class BatchWriter:
                 xids.extend(group_data.get('associatedGroupXid', []))
 
     @staticmethod
-    def data_group_type(group_data: Union[dict, GroupType]) -> Tuple[dict, dict]:
+    def data_group_type(group_data: Union[dict, 'GroupType']) -> Tuple[dict, dict]:
         """Return dict representation of group data and file data.
 
         Args:
@@ -712,7 +715,7 @@ class BatchWriter:
 
         return False
 
-    def document(self, name: str, file_name: str, **kwargs) -> Document:
+    def document(self, name: str, file_name: str, **kwargs) -> 'Document':
         """Add Document data to Batch.
 
         Args:
@@ -733,7 +736,7 @@ class BatchWriter:
         group_obj = Document(name, file_name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def dump(self) -> None:
+    def dump(self):
         """Process Batch request to ThreatConnect API."""
         content = self.data
         content.pop('file', {})
@@ -756,7 +759,7 @@ class BatchWriter:
         # reset batch size after dump
         self._batch_size = 0
 
-    def email(self, name: str, subject: str, header: str, body: str, **kwargs) -> Email:
+    def email(self, name: str, subject: str, header: str, body: str, **kwargs) -> 'Email':
         """Add Email data to Batch.
 
         Args:
@@ -777,7 +780,7 @@ class BatchWriter:
         group_obj = Email(name, subject, header, body, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def email_address(self, address: str, **kwargs) -> EmailAddress:
+    def email_address(self, address: str, **kwargs) -> 'EmailAddress':
         """Add Email Address data to Batch.
 
         Args:
@@ -796,7 +799,7 @@ class BatchWriter:
         indicator_obj = EmailAddress(address, **kwargs)
         return self._indicator(indicator_obj, kwargs.get('store', True))
 
-    def event(self, name: str, **kwargs) -> Event:
+    def event(self, name: str, **kwargs) -> 'Event':
         """Add Event data to Batch.
 
         Args:
@@ -820,7 +823,7 @@ class BatchWriter:
         sha1: Optional[str] = None,
         sha256: Optional[str] = None,
         **kwargs,
-    ) -> File:
+    ) -> 'File':
         """Add File data to Batch.
 
         .. note:: A least one file hash value must be specified.
@@ -865,7 +868,7 @@ class BatchWriter:
             identifier = hashlib.sha256(identifier.encode('utf-8')).hexdigest()
         return hashlib.sha256(identifier.encode('utf-8')).hexdigest()
 
-    def group(self, group_type: str, name: str, **kwargs) -> GroupType:
+    def group(self, group_type: str, name: str, **kwargs) -> 'GroupType':
         """Add Group data to Batch.
 
         Args:
@@ -905,13 +908,13 @@ class BatchWriter:
         return self._groups
 
     @property
-    def groups_shelf(self) -> shelve.DbfilenameShelf:
+    def groups_shelf(self) -> 'shelve.DbfilenameShelf':
         """Return dictionary of all Groups data."""
         if self._groups_shelf is None:
             self._groups_shelf = shelve.open(self.group_shelf_fqfn, writeback=False)  # nosec
         return self._groups_shelf
 
-    def host(self, hostname: str, **kwargs) -> Host:
+    def host(self, hostname: str, **kwargs) -> 'Host':
         """Add Host data to Batch.
 
         Args:
@@ -932,7 +935,7 @@ class BatchWriter:
         indicator_obj = Host(hostname, **kwargs)
         return self._indicator(indicator_obj, kwargs.get('store', True))
 
-    def incident(self, name: str, **kwargs) -> Incident:
+    def incident(self, name: str, **kwargs) -> 'Incident':
         """Add Incident data to Batch.
 
         Args:
@@ -950,7 +953,7 @@ class BatchWriter:
         group_obj = Incident(name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def indicator(self, indicator_type: str, summary: str, **kwargs) -> IndicatorType:
+    def indicator(self, indicator_type: str, summary: str, **kwargs) -> 'IndicatorType':
         """Add Indicator data to Batch.
 
         Args:
@@ -993,7 +996,7 @@ class BatchWriter:
         return self._indicators
 
     @property
-    def indicators_shelf(self) -> shelve.DbfilenameShelf:
+    def indicators_shelf(self) -> 'shelve.DbfilenameShelf':
         """Return dictionary of all Indicator data."""
         if self._indicators_shelf is None:
             self._indicators_shelf = shelve.open(  # nosec
@@ -1001,7 +1004,7 @@ class BatchWriter:
             )
         return self._indicators_shelf
 
-    def intrusion_set(self, name: str, **kwargs) -> IntrusionSet:
+    def intrusion_set(self, name: str, **kwargs) -> 'IntrusionSet':
         """Add Intrusion Set data to Batch.
 
         Args:
@@ -1017,7 +1020,7 @@ class BatchWriter:
         group_obj = IntrusionSet(name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def malware(self, name: str, **kwargs) -> Malware:
+    def malware(self, name: str, **kwargs) -> 'Malware':
         """Add Malware data to Batch object.
 
         Args:
@@ -1033,7 +1036,7 @@ class BatchWriter:
         group_obj = Malware(name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def mutex(self, mutex: str, **kwargs) -> Mutex:
+    def mutex(self, mutex: str, **kwargs) -> 'Mutex':
         """Add Mutex data to Batch.
 
         Args:
@@ -1054,7 +1057,7 @@ class BatchWriter:
 
     def registry_key(
         self, key_name: str, value_name: str, value_type: str, **kwargs
-    ) -> RegistryKey:
+    ) -> 'RegistryKey':
         """Add Registry Key data to Batch.
 
         Args:
@@ -1075,7 +1078,7 @@ class BatchWriter:
         indicator_obj = RegistryKey(key_name, value_name, value_type, **kwargs)
         return self._indicator(indicator_obj, kwargs.get('store', True))
 
-    def report(self, name: str, **kwargs) -> Report:
+    def report(self, name: str, **kwargs) -> 'Report':
         """Add Report data to Batch.
 
         Args:
@@ -1095,7 +1098,7 @@ class BatchWriter:
         group_obj = Report(name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def save(self, resource: Union[dict, GroupType, IndicatorType]) -> None:
+    def save(self, resource: Union[dict, 'GroupType', 'IndicatorType']):
         """Save group|indicator dict, GroupType, or IndicatorTypes to shelve.
 
         Best effort to save group/indicator data to disk.  If for any reason the save fails
@@ -1145,7 +1148,7 @@ class BatchWriter:
 
     def signature(
         self, name: str, file_name: str, file_type: str, file_text: str, **kwargs
-    ) -> Signature:
+    ) -> 'Signature':
         """Add Signature data to Batch.
 
         Valid file_types:
@@ -1175,7 +1178,7 @@ class BatchWriter:
         group_obj = Signature(name, file_name, file_type, file_text, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def tactic(self, name: str, **kwargs) -> Tactic:
+    def tactic(self, name: str, **kwargs) -> 'Tactic':
         """Add Tactic data to Batch object.
 
         Args:
@@ -1191,7 +1194,7 @@ class BatchWriter:
         group_obj = Tactic(name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def threat(self, name: str, **kwargs) -> Threat:
+    def threat(self, name: str, **kwargs) -> 'Threat':
         """Add Threat data to Batch.
 
         Args:
@@ -1207,7 +1210,7 @@ class BatchWriter:
         group_obj = Threat(name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def tool(self, name: str, **kwargs) -> Tool:
+    def tool(self, name: str, **kwargs) -> 'Tool':
         """Add Tool data to Batch object.
 
         Args:
@@ -1223,7 +1226,7 @@ class BatchWriter:
         group_obj = Tool(name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def user_agent(self, text: str, **kwargs) -> UserAgent:
+    def user_agent(self, text: str, **kwargs) -> 'UserAgent':
         """Add User Agent data to Batch.
 
         Args:
@@ -1242,7 +1245,7 @@ class BatchWriter:
         indicator_obj = UserAgent(text, **kwargs)
         return self._indicator(indicator_obj, kwargs.get('store', True))
 
-    def url(self, text: str, **kwargs) -> URL:
+    def url(self, text: str, **kwargs) -> 'URL':
         """Add URL Address data to Batch.
 
         Args:
@@ -1261,7 +1264,7 @@ class BatchWriter:
         indicator_obj = URL(text, **kwargs)
         return self._indicator(indicator_obj, kwargs.get('store', True))
 
-    def vulnerability(self, name: str, **kwargs) -> Vulnerability:
+    def vulnerability(self, name: str, **kwargs) -> 'Vulnerability':
         """Add Vulnerability data to Batch.
 
         Args:
@@ -1277,7 +1280,7 @@ class BatchWriter:
         group_obj = Vulnerability(name, **kwargs)
         return self._group(group_obj, kwargs.get('store', True))
 
-    def write_batch_json(self, content: dict) -> None:
+    def write_batch_json(self, content: dict):
         """Write batch json data to a file."""
         if content:
             # get timestamp as a string without decimal place and consistent length

--- a/tcex/api/tc/v2/batch/group.py
+++ b/tcex/api/tc/v2/batch/group.py
@@ -30,7 +30,7 @@ class Group:
         'utils',
     ]
 
-    def __init__(self, group_type: str, name: str, **kwargs) -> None:
+    def __init__(self, group_type: str, name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -72,9 +72,7 @@ class Group:
             'to_addr': 'to',
         }
 
-    def add_file(
-        self, filename: str, file_content: Union[bytes, Callable[[str], Any], str]
-    ) -> None:
+    def add_file(self, filename: str, file_content: Union[bytes, Callable[[str], Any], str]):
         """Add a file for Document and Report types.
 
         Example::
@@ -89,7 +87,7 @@ class Group:
         self._group_data['fileName'] = filename
         self._file_content = file_content
 
-    def add_key_value(self, key: str, value: str) -> None:
+    def add_key_value(self, key: str, value: str):
         """Add custom field to Group object.
 
         .. note:: The key must be the exact name required by the batch schema.
@@ -115,7 +113,7 @@ class Group:
         else:
             self._group_data[key] = value
 
-    def association(self, group_xid: str) -> None:
+    def association(self, group_xid: str):
         """Add association using xid value.
 
         Args:
@@ -197,7 +195,7 @@ class Group:
         return self._group_data.get('dateAdded')
 
     @date_added.setter
-    def date_added(self, date_added: str) -> None:
+    def date_added(self, date_added: str):
         """Set Indicator dateAdded."""
         self._group_data['dateAdded'] = self.utils.any_to_datetime(date_added).strftime(
             '%Y-%m-%dT%H:%M:%SZ'
@@ -226,7 +224,7 @@ class Group:
         return self._processed
 
     @processed.setter
-    def processed(self, processed: bool) -> None:
+    def processed(self, processed: bool):
         """Set processed."""
         self._processed = processed
 
@@ -255,7 +253,7 @@ class Group:
             self._labels.append(label)
         return label
 
-    def tag(self, name: str, formatter: Optional[Callable[[str], str]] = None) -> Tag:
+    def tag(self, name: str, formatter: Optional[Callable[[str], str]] = None) -> 'Tag':
         """Return instance of Tag.
 
         Args:
@@ -294,7 +292,7 @@ class Adversary(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -310,7 +308,7 @@ class AttackPattern(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -326,7 +324,7 @@ class Campaign(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -343,7 +341,7 @@ class Campaign(Group):
         return self._group_data.get('firstSeen')
 
     @first_seen.setter
-    def first_seen(self, first_seen: str) -> None:
+    def first_seen(self, first_seen: str):
         """Set Document first seen."""
         self._group_data['firstSeen'] = self.utils.any_to_datetime(first_seen).strftime(
             '%Y-%m-%dT%H:%M:%SZ'
@@ -355,7 +353,7 @@ class CourseOfAction(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -371,7 +369,7 @@ class Document(Group):
 
     __slots__ = ['_file_data']
 
-    def __init__(self, name: str, file_name: str, **kwargs) -> None:
+    def __init__(self, name: str, file_name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -414,7 +412,7 @@ class Document(Group):
         return self._group_data.get('password', False)
 
     @password.setter
-    def password(self, password: str) -> None:
+    def password(self, password: str):
         """Set Document password."""
         self._group_data['password'] = password
 
@@ -424,7 +422,7 @@ class Email(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, subject: str, header: str, body: str, **kwargs) -> None:
+    def __init__(self, name: str, subject: str, header: str, body: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -449,7 +447,7 @@ class Email(Group):
         return self._group_data.get('to')
 
     @from_addr.setter
-    def from_addr(self, from_addr: str) -> None:
+    def from_addr(self, from_addr: str):
         """Set Email from."""
         self._group_data['from'] = from_addr
 
@@ -459,7 +457,7 @@ class Email(Group):
         return self._group_data.get('score')
 
     @score.setter
-    def score(self, score: str) -> None:
+    def score(self, score: str):
         """Set Email from."""
         self._group_data['score'] = score
 
@@ -469,7 +467,7 @@ class Email(Group):
         return self._group_data.get('to')
 
     @to_addr.setter
-    def to_addr(self, to_addr: str) -> None:
+    def to_addr(self, to_addr: str):
         """Set Email to."""
         self._group_data['to'] = to_addr
 
@@ -479,7 +477,7 @@ class Event(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Valid Values:
@@ -503,7 +501,7 @@ class Event(Group):
         return self._group_data.get('firstSeen')
 
     @event_date.setter
-    def event_date(self, event_date: str) -> None:
+    def event_date(self, event_date: str):
         """Set the Events "event date" value."""
         self._group_data['eventDate'] = self.utils.any_to_datetime(event_date).strftime(
             '%Y-%m-%dT%H:%M:%SZ'
@@ -515,7 +513,7 @@ class Event(Group):
         return self._group_data.get('status')
 
     @status.setter
-    def status(self, status: str) -> None:
+    def status(self, status: str):
         """Set the Events status value."""
         self._group_data['status'] = status
 
@@ -525,7 +523,7 @@ class Incident(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Valid Values:
@@ -554,7 +552,7 @@ class Incident(Group):
         return self._group_data.get('eventDate')
 
     @event_date.setter
-    def event_date(self, event_date: str) -> None:
+    def event_date(self, event_date: str):
         """Set Incident event_date."""
         self._group_data['eventDate'] = self.utils.any_to_datetime(event_date).strftime(
             '%Y-%m-%dT%H:%M:%SZ'
@@ -566,7 +564,7 @@ class Incident(Group):
         return self._group_data.get('status')
 
     @status.setter
-    def status(self, status: str) -> None:
+    def status(self, status: str):
         """Set Incident status.
 
         Valid Values:
@@ -588,7 +586,7 @@ class IntrusionSet(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -604,7 +602,7 @@ class Malware(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -620,7 +618,7 @@ class Report(Group):
 
     __slots__ = []
 
-    def __init__(self, name, **kwargs) -> None:
+    def __init__(self, name, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -651,7 +649,7 @@ class Report(Group):
         return self._group_data.get('publishDate')
 
     @publish_date.setter
-    def publish_date(self, publish_date: str) -> None:
+    def publish_date(self, publish_date: str):
         """Set Report publish date"""
         self._group_data['publishDate'] = self.utils.any_to_datetime(publish_date).strftime(
             '%Y-%m-%dT%H:%M:%SZ'
@@ -663,7 +661,7 @@ class Signature(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, file_name: str, file_type: str, file_text: str, **kwargs) -> None:
+    def __init__(self, name: str, file_name: str, file_type: str, file_text: str, **kwargs):
         """Initialize Class Properties.
 
         Valid file_types:
@@ -696,7 +694,7 @@ class Tactic(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -712,7 +710,7 @@ class Threat(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -728,7 +726,7 @@ class Tool(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -744,7 +742,7 @@ class Vulnerability(Group):
 
     __slots__ = []
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs):
         """Initialize Class Properties.
 
         Args:

--- a/tcex/api/tc/v2/batch/indicator.py
+++ b/tcex/api/tc/v2/batch/indicator.py
@@ -18,9 +18,7 @@ def custom_indicator_class_factory(indicator_type, base_class, class_dict, value
     """Return internal methods for dynamically building Custom Indicator Class."""
     value_count = len(value_fields)
 
-    def init_1(  # pylint: disable=possibly-unused-variable
-        self, tcex, value1, xid, **kwargs
-    ) -> None:
+    def init_1(self, tcex, value1, xid, **kwargs):  # pylint: disable=possibly-unused-variable
         """Init method for Custom Indicator Types with one value"""
         summary = self.build_summary(value1)  # build the indicator summary
         base_class.__init__(self, tcex, indicator_type, summary, xid, **kwargs)
@@ -29,7 +27,7 @@ def custom_indicator_class_factory(indicator_type, base_class, class_dict, value
 
     def init_2(  # pylint: disable=possibly-unused-variable
         self, tcex, value1, value2, xid, **kwargs
-    ) -> None:
+    ):
         """Init method for Custom Indicator Types with two values."""
         summary = self.build_summary(value1, value2)  # build the indicator summary
         base_class.__init__(self, tcex, indicator_type, summary, xid, **kwargs)
@@ -38,7 +36,7 @@ def custom_indicator_class_factory(indicator_type, base_class, class_dict, value
 
     def init_3(  # pylint: disable=possibly-unused-variable
         self, tcex, value1, value2, value3, xid, **kwargs
-    ) -> None:
+    ):
         """Init method for Custom Indicator Types with three values."""
         summary = self.build_summary(value1, value2, value3)  # build the indicator summary
         base_class.__init__(self, tcex, indicator_type, summary, xid, **kwargs)
@@ -66,7 +64,7 @@ class Indicator:
         'utils',
     ]
 
-    def __init__(self, indicator_type: str, summary: str, **kwargs) -> None:
+    def __init__(self, indicator_type: str, summary: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -113,7 +111,7 @@ class Indicator:
             'whois_active': 'flag2',
         }
 
-    def add_key_value(self, key: str, value: str) -> None:
+    def add_key_value(self, key: str, value: str):
         """Add custom field to Indicator object.
 
         .. note:: The key must be the exact name required by the batch schema.
@@ -145,11 +143,11 @@ class Indicator:
         return self._indicator_data.get('active')
 
     @active.setter
-    def active(self, active: bool) -> None:
+    def active(self, active: bool):
         """Set Indicator active."""
         self._indicator_data['active'] = self.utils.to_bool(active)
 
-    def association(self, group_xid: str) -> None:
+    def association(self, group_xid: str):
         """Add association using xid value.
 
         Args:
@@ -228,7 +226,7 @@ class Indicator:
         return self._indicator_data.get('confidence')
 
     @confidence.setter
-    def confidence(self, confidence: int) -> None:
+    def confidence(self, confidence: int):
         """Set Indicator confidence."""
         self._indicator_data['confidence'] = int(confidence)
 
@@ -271,7 +269,7 @@ class Indicator:
         return self._indicator_data.get('dateAdded')
 
     @date_added.setter
-    def date_added(self, date_added: str) -> None:
+    def date_added(self, date_added: str):
         """Set Indicator dateAdded."""
         self._indicator_data['dateAdded'] = self.utils.any_to_datetime(date_added).strftime(
             '%Y-%m-%dT%H:%M:%SZ'
@@ -283,7 +281,7 @@ class Indicator:
         return self._indicator_data.get('lastModified')
 
     @last_modified.setter
-    def last_modified(self, last_modified: str) -> None:
+    def last_modified(self, last_modified: str):
         """Set Indicator lastModified."""
         self._indicator_data['lastModified'] = self.utils.any_to_datetime(last_modified).strftime(
             '%Y-%m-%dT%H:%M:%SZ'
@@ -319,7 +317,7 @@ class Indicator:
         return self._indicator_data.get('privateFlag')
 
     @private_flag.setter
-    def private_flag(self, private_flag: bool) -> None:
+    def private_flag(self, private_flag: bool):
         """Set Indicator private flag."""
         self._indicator_data['privateFlag'] = self.utils.to_bool(private_flag)
 
@@ -329,7 +327,7 @@ class Indicator:
         return self._indicator_data.get('rating')
 
     @rating.setter
-    def rating(self, rating: float) -> None:
+    def rating(self, rating: float):
         """Set Indicator rating."""
         self._indicator_data['rating'] = float(rating)
 
@@ -363,7 +361,7 @@ class Indicator:
             self._labels.append(label)
         return label
 
-    def tag(self, name: str, formatter: Optional[Callable[[str], str]] = None) -> Tag:
+    def tag(self, name: str, formatter: Optional[Callable[[str], str]] = None) -> 'Tag':
         """Return instance of Tag.
 
         Args:
@@ -402,7 +400,7 @@ class Address(Indicator):
 
     __slots__ = []
 
-    def __init__(self, ip: str, **kwargs) -> None:
+    def __init__(self, ip: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -423,7 +421,7 @@ class ASN(Indicator):
 
     __slots__ = []
 
-    def __init__(self, as_number: str, **kwargs) -> None:
+    def __init__(self, as_number: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -444,7 +442,7 @@ class CIDR(Indicator):
 
     __slots__ = []
 
-    def __init__(self, block: str, **kwargs) -> None:
+    def __init__(self, block: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -465,7 +463,7 @@ class EmailAddress(Indicator):
 
     __slots__ = []
 
-    def __init__(self, address: str, **kwargs) -> None:
+    def __init__(self, address: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -492,7 +490,7 @@ class File(Indicator):
         sha1: Optional[str] = None,
         sha256: Optional[str] = None,
         **kwargs,
-    ) -> None:
+    ):
         """Initialize Class Properties.
 
         Args:
@@ -544,7 +542,7 @@ class File(Indicator):
         return self._indicator_data.get('sha256')
 
     @sha256.setter
-    def sha256(self, sha256: str) -> None:
+    def sha256(self, sha256: str):
         """Set Indicator sha256."""
         self._indicator_data['sha256'] = sha256
 
@@ -554,7 +552,7 @@ class File(Indicator):
         return self._indicator_data.get('intValue1')
 
     @size.setter
-    def size(self, size: int) -> None:
+    def size(self, size: int):
         """Set Indicator size."""
         self._indicator_data['intValue1'] = size
 
@@ -564,7 +562,7 @@ class Host(Indicator):
 
     __slots__ = []
 
-    def __init__(self, hostname: str, **kwargs) -> None:
+    def __init__(self, hostname: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -587,7 +585,7 @@ class Host(Indicator):
         return self._indicator_data.get('flag1')
 
     @dns_active.setter
-    def dns_active(self, dns_active: bool) -> None:
+    def dns_active(self, dns_active: bool):
         """Set Indicator dns active."""
         self._indicator_data['flag1'] = self.utils.to_bool(dns_active)
 
@@ -597,7 +595,7 @@ class Host(Indicator):
         return self._indicator_data.get('flag2')
 
     @whois_active.setter
-    def whois_active(self, whois_active: bool) -> None:
+    def whois_active(self, whois_active: bool):
         """Set Indicator whois active."""
         self._indicator_data['flag2'] = self.utils.to_bool(whois_active)
 
@@ -607,7 +605,7 @@ class Mutex(Indicator):
 
     __slots__ = []
 
-    def __init__(self, mutex: str, **kwargs) -> None:
+    def __init__(self, mutex: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -628,7 +626,7 @@ class RegistryKey(Indicator):
 
     __slots__ = []
 
-    def __init__(self, key_name: str, value_name: str, value_type: str, **kwargs) -> None:
+    def __init__(self, key_name: str, value_name: str, value_type: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -652,7 +650,7 @@ class URL(Indicator):
 
     __slots__ = []
 
-    def __init__(self, text: str, **kwargs) -> None:
+    def __init__(self, text: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -673,7 +671,7 @@ class UserAgent(Indicator):
 
     __slots__ = []
 
-    def __init__(self, text: str, **kwargs) -> None:
+    def __init__(self, text: str, **kwargs):
         """Initialize Class Properties.
 
         Args:
@@ -694,7 +692,7 @@ class FileAction:
 
     __slots__ = ['_action_data', '_children', 'xid']
 
-    def __init__(self, parent_xid: str, relationship) -> None:
+    def __init__(self, parent_xid: str, relationship):
         """Initialize Class Properties.
 
         .. warning:: This code is not complete and may require some update to the API.
@@ -719,7 +717,7 @@ class FileAction:
                 self._action_data.setdefault('children', []).append(child.data)
         return self._action_data
 
-    def action(self, relationship) -> None:
+    def action(self, relationship):
         """Add a nested File Action."""
         action_obj = FileAction(self.xid, relationship)
         self._children.append(action_obj)
@@ -739,7 +737,7 @@ class FileOccurrence:
         file_name: Optional[str] = None,
         path: Optional[str] = None,
         date: Optional[str] = None,
-    ) -> None:
+    ):
         """Initialize Class Properties
 
         Args:
@@ -772,7 +770,7 @@ class FileOccurrence:
         return self._occurrence_data.get('date')
 
     @date.setter
-    def date(self, date: str) -> None:
+    def date(self, date: str):
         """Set File Occurrence date."""
         self._occurrence_data['date'] = self.utils.any_to_datetime(date).strftime(
             '%Y-%m-%dT%H:%M:%SZ'
@@ -784,7 +782,7 @@ class FileOccurrence:
         return self._occurrence_data.get('fileName')
 
     @file_name.setter
-    def file_name(self, file_name: str) -> None:
+    def file_name(self, file_name: str):
         """Set File Occurrence file name."""
         self._occurrence_data['fileName'] = file_name
 
@@ -794,7 +792,7 @@ class FileOccurrence:
         return self._occurrence_data.get('path')
 
     @path.setter
-    def path(self, path: str) -> None:
+    def path(self, path: str):
         """Set File Occurrence path."""
         self._occurrence_data['path'] = path
 

--- a/tcex/api/tc/v2/batch/security_label.py
+++ b/tcex/api/tc/v2/batch/security_label.py
@@ -9,9 +9,7 @@ class SecurityLabel:
 
     __slots__ = ['_label_data']
 
-    def __init__(
-        self, name: str, description: Optional[str] = None, color: Optional[str] = None
-    ) -> None:
+    def __init__(self, name: str, description: Optional[str] = None, color: Optional[str] = None):
         """Initialize Class Properties.
 
         Args:
@@ -32,7 +30,7 @@ class SecurityLabel:
         return self._label_data.get('color')
 
     @color.setter
-    def color(self, color: str) -> None:
+    def color(self, color: str):
         """Set Security Label color."""
         self._label_data['color'] = color
 
@@ -47,7 +45,7 @@ class SecurityLabel:
         return self._label_data.get('description')
 
     @description.setter
-    def description(self, description: str) -> None:
+    def description(self, description: str):
         """Set Security Label description."""
         self._label_data['description'] = description
 

--- a/tcex/api/tc/v2/batch/tag.py
+++ b/tcex/api/tc/v2/batch/tag.py
@@ -9,7 +9,7 @@ class Tag:
 
     __slots__ = ['_tag_data', '_valid']
 
-    def __init__(self, name: str, formatter: Optional[Callable[[str], str]] = None) -> None:
+    def __init__(self, name: str, formatter: Optional[Callable[[str], str]] = None):
         """Initialize Class Properties.
 
         Args:

--- a/tcex/api/tc/v2/datastore/datastore.py
+++ b/tcex/api/tc/v2/datastore/datastore.py
@@ -41,7 +41,7 @@ class DataStore:
 
     def __init__(
         self, session_tc: 'Session', domain: str, data_type: str, mapping: Optional[dict] = None
-    ) -> None:
+    ):
         """Initialize class properties."""
         self.domain = domain
         self.data_type = data_type
@@ -55,7 +55,7 @@ class DataStore:
         self._create_index()  # create the initial index.
         self._update_mappings()  # update mappings
 
-    def _create_index(self) -> None:
+    def _create_index(self):
         """Create index if it doesn't exist."""
         if not self.index_exists:
             rid = 'temp-index-create'
@@ -71,7 +71,7 @@ class DataStore:
             # delete temporary record
             self.delete(rid, False)
 
-    def _update_mappings(self) -> None:
+    def _update_mappings(self):
         """Update the mappings for the current index."""
         headers = {'Content-Type': 'application/json', 'DB-Method': 'PUT'}
         url = f'/v2/exchange/db/{self.domain}/{self.data_type}/_mappings'

--- a/tcex/api/tc/v2/threat_intelligence/mappings/mappings.py
+++ b/tcex/api/tc/v2/threat_intelligence/mappings/mappings.py
@@ -51,7 +51,7 @@ class Mappings:
 
     @property
     @lru_cache()
-    def _error_codes(self) -> TcExErrorCodes:  # noqa: F821
+    def _error_codes(self) -> 'TcExErrorCodes':  # noqa: F821
         """Return TcEx error codes."""
         return TcExErrorCodes()
 
@@ -62,7 +62,7 @@ class Mappings:
 
     def _handle_error(
         self, code: int, message_values: Optional[list] = None, raise_error: Optional[bool] = True
-    ) -> None:
+    ):
         """Raise RuntimeError
 
         Args:

--- a/tcex/api/tc/v2/threat_intelligence/tcex_ti_tc_request.py
+++ b/tcex/api/tc/v2/threat_intelligence/tcex_ti_tc_request.py
@@ -22,7 +22,7 @@ logger = logging.getLogger('tcex')
 class TiTcRequest:
     """Common API calls to ThreatConnect"""
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: Session):
         """Initialize Class properties."""
         self.session = session
 
@@ -51,7 +51,7 @@ class TiTcRequest:
 
     @property
     @lru_cache()
-    def _error_codes(self) -> TcExErrorCodes:  # noqa: F821
+    def _error_codes(self) -> 'TcExErrorCodes':  # noqa: F821
         """Return TcEx error codes."""
         return TcExErrorCodes()
 
@@ -77,7 +77,7 @@ class TiTcRequest:
 
     def _handle_error(
         self, code: int, message_values: Optional[list] = None, raise_error: Optional[bool] = True
-    ) -> None:
+    ):
         """Raise RuntimeError
 
         Args:

--- a/tcex/api/tc/v2/threat_intelligence/threat_intelligence.py
+++ b/tcex/api/tc/v2/threat_intelligence/threat_intelligence.py
@@ -63,7 +63,7 @@ logger = logging.getLogger('tcex')
 class ThreatIntelligence:
     """ThreatConnect Threat Intelligence Module"""
 
-    def __init__(self, session_tc: 'Session') -> None:
+    def __init__(self, session_tc: 'Session'):
         """Initialize Class properties."""
         self.session_tc = session_tc
 
@@ -77,7 +77,7 @@ class ThreatIntelligence:
 
     @property
     @lru_cache()
-    def _error_codes(self) -> TcExErrorCodes:  # noqa: F821
+    def _error_codes(self) -> 'TcExErrorCodes':  # noqa: F821
         """Return TcEx error codes."""
         return TcExErrorCodes()
 
@@ -157,7 +157,7 @@ class ThreatIntelligence:
 
     def _handle_error(
         self, code: int, message_values: Optional[list] = None, raise_error: Optional[bool] = True
-    ) -> None:
+    ):
         """Raise RuntimeError
 
         Args:

--- a/tcex/api/tc/v2/v2.py
+++ b/tcex/api/tc/v2/v2.py
@@ -27,7 +27,7 @@ class V2:
         session_tc: An configured instance of request.Session with TC API Auth.
     """
 
-    def __init__(self, inputs: 'Input', session_tc: 'Session') -> None:
+    def __init__(self, inputs: 'Input', session_tc: 'Session'):
         """Initialize Class properties."""
         self.inputs = inputs
         self.session_tc = session_tc

--- a/tcex/api/tc/v3/_gen/_gen.py
+++ b/tcex/api/tc/v3/_gen/_gen.py
@@ -29,7 +29,7 @@ class GenerateArgs(GenerateArgsABC):
 class GenerateFilter(GenerateFilterABC):
     """Generate Models for TC API Types"""
 
-    def __init__(self, type_: str) -> None:
+    def __init__(self, type_: str):
         """Initialize class properties."""
         super().__init__(type_)
 
@@ -41,7 +41,7 @@ class GenerateFilter(GenerateFilterABC):
 class GenerateModel(GenerateModelABC):
     """Generate Models for TC API Types"""
 
-    def __init__(self, type_: str) -> None:
+    def __init__(self, type_: str):
         """Initialize class properties."""
         super().__init__(type_)
 
@@ -53,7 +53,7 @@ class GenerateModel(GenerateModelABC):
 class GenerateObject(GenerateObjectABC):
     """Generate Models for TC API Types"""
 
-    def __init__(self, type_: str) -> None:
+    def __init__(self, type_: str):
         """Initialize class properties."""
         super().__init__(type_)
 
@@ -86,7 +86,7 @@ def format_code(_code):
     return _code
 
 
-def gen_args(type_: str, indent_blocks: int) -> None:
+def gen_args(type_: str, indent_blocks: int):
     """Generate args code."""
     # get instance of doc generator
     gen = GenerateArgs(type_)
@@ -97,7 +97,7 @@ def gen_args(type_: str, indent_blocks: int) -> None:
     print(gen.gen_args(i1=i1, i2=i2))
 
 
-def gen_filter(type_: str) -> None:
+def gen_filter(type_: str):
     """Generate the filter code."""
     # get instance of filter generator
     gen = GenerateFilter(type_)
@@ -125,7 +125,7 @@ def gen_filter(type_: str) -> None:
     typer.secho(f'Successfully wrote {out_file}.', fg=typer.colors.GREEN)
 
 
-def gen_model(type_: str) -> None:
+def gen_model(type_: str):
     """Generate model code."""
     # get instance of model generator
     gen = GenerateModel(type_)
@@ -170,7 +170,7 @@ def gen_model(type_: str) -> None:
     typer.secho(f'Successfully wrote {out_file}.', fg=typer.colors.GREEN)
 
 
-def gen_object(type_: str) -> None:
+def gen_object(type_: str):
     """Generate object code."""
     # get instance of filter generator
     gen = GenerateObject(type_)

--- a/tcex/api/tc/v3/_gen/_gen_abc.py
+++ b/tcex/api/tc/v3/_gen/_gen_abc.py
@@ -20,7 +20,7 @@ from tcex.utils import Utils
 class GenerateABC(ABC):
     """Generate Abstract Base Class"""
 
-    def __init__(self, type_: Any) -> None:
+    def __init__(self, type_: Any):
         """Initialize class properties."""
         self.type_ = type_
 
@@ -201,7 +201,7 @@ class GenerateABC(ABC):
         return '\n'.join(_libs)
 
     @property
-    def session(self) -> Session:
+    def session(self) -> 'Session':
         """Return Session configured for TC API."""
         _session = Session()
         _session.auth = HmacAuth(

--- a/tcex/api/tc/v3/_gen/_gen_args_abc.py
+++ b/tcex/api/tc/v3/_gen/_gen_args_abc.py
@@ -12,7 +12,7 @@ from tcex.api.tc.v3._gen._gen_abc import GenerateABC
 class GenerateArgsABC(GenerateABC, ABC):
     """Generate docstring for Model."""
 
-    def __init__(self, type_: Any) -> None:
+    def __init__(self, type_: Any):
         """Initialize class properties."""
         super().__init__(type_)
         self.type_ = self.utils.snake_string(self._type_map(type_))

--- a/tcex/api/tc/v3/_gen/_gen_filter_abc.py
+++ b/tcex/api/tc/v3/_gen/_gen_filter_abc.py
@@ -14,7 +14,7 @@ from tcex.backports import cached_property
 class GenerateFilterABC(GenerateABC, ABC):
     """Generate Models for Case Management Types"""
 
-    def __init__(self, type_: str) -> None:
+    def __init__(self, type_: str):
         """Initialize class properties."""
         super().__init__(type_)
 
@@ -143,7 +143,7 @@ class GenerateFilterABC(GenerateABC, ABC):
             (
                 f'{self.i1}def {keyword.snake_case()}'
                 f'(self, operator: Enum, {keyword.snake_case()}: '
-                f'''{self._filter_type(type_).get('hint_type')}) -> None:{comment}'''
+                f'''{self._filter_type(type_).get('hint_type')}):{comment}'''
             ),
             f'{self.i2}"""Filter {name} based on **{keyword}** keyword.',
             '',

--- a/tcex/api/tc/v3/_gen/_gen_model_abc.py
+++ b/tcex/api/tc/v3/_gen/_gen_model_abc.py
@@ -12,7 +12,7 @@ from tcex.api.tc.v3._gen._gen_abc import GenerateABC
 class GenerateModelABC(GenerateABC, ABC):
     """Generate Models for Case Management Types"""
 
-    def __init__(self, type_: str) -> None:
+    def __init__(self, type_: str):
         """Initialize class properties."""
         super().__init__(type_)
 
@@ -30,7 +30,7 @@ class GenerateModelABC(GenerateABC, ABC):
         }
         self.validators = {}
 
-    def _add_module_class(self, from_: str, module: str, class_: str) -> None:
+    def _add_module_class(self, from_: str, module: str, class_: str):
         """Add pydantic validator only when required."""
         for lib in self.requirements[from_]:
             if isinstance(lib, dict):

--- a/tcex/api/tc/v3/_gen/_gen_object_abc.py
+++ b/tcex/api/tc/v3/_gen/_gen_object_abc.py
@@ -15,7 +15,7 @@ class GenerateArgs(GenerateArgsABC):
 class GenerateObjectABC(GenerateABC, ABC):
     """Generate Models for Case Management Types"""
 
-    def __init__(self, type_: str) -> None:
+    def __init__(self, type_: str):
         """Initialize class properties."""
         super().__init__(type_)
 
@@ -54,7 +54,7 @@ class GenerateObjectABC(GenerateABC, ABC):
     def _gen_code_container_init_method(self) -> str:
         """Return the method code.
 
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs):
             '''Initialize Class properties.'''
             super().__init__(
                 kwargs.pop('session', None),
@@ -72,7 +72,7 @@ class GenerateObjectABC(GenerateABC, ABC):
 
         return '\n'.join(
             [
-                f'''{self.i1}def __init__(self, **kwargs) -> None:''',
+                f'''{self.i1}def __init__(self, **kwargs):''',
                 f'''{self.i2}"""Initialize class properties."""''',
                 f'''{self.i2}super().__init__(''',
                 (
@@ -146,7 +146,7 @@ class GenerateObjectABC(GenerateABC, ABC):
                 f'''{self.i2}deleted_since: Optional[Union[datetime, str]],''',
                 f'''{self.i2}type_: Optional[str] = None,''',
                 f'''{self.i2}owner: Optional[str] = None''',
-                f'''{self.i1}) -> None:''',
+                f'''{self.i1}):''',
                 f'''{self.i2}"""Return deleted indicators.''',
                 '',
                 f'''{self.i2}This will not use the default params set on the "Indicators" ''',
@@ -229,7 +229,7 @@ class GenerateObjectABC(GenerateABC, ABC):
     def _gen_code_object_init_method(self) -> str:
         """Return the method code.
 
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs):
             '''Initialize Class properties'''
             super().__init__(kwargs.pop('session', None))
             self._model = ArtifactModel(**kwargs)
@@ -249,7 +249,7 @@ class GenerateObjectABC(GenerateABC, ABC):
 
         return '\n'.join(
             [
-                f'''{self.i1}def __init__(self, **kwargs) -> None:''',
+                f'''{self.i1}def __init__(self, **kwargs):''',
                 f'''{self.i2}"""Initialize class properties."""''',
                 f'''{self.i2}super().__init__(kwargs.pop('session', None))''',
                 '',
@@ -275,7 +275,7 @@ class GenerateObjectABC(GenerateABC, ABC):
             return self._model
 
         @model.setter
-        def model(self, data: Union['IndicatorModel', dict]) -> None:
+        def model(self, data: Union['IndicatorModel', dict]):
             '''Create model using the provided data.'''
             if isinstance(data, type(self.model)):
                 # provided data is already a model, nothing required to change
@@ -296,7 +296,7 @@ class GenerateObjectABC(GenerateABC, ABC):
                 f'''{self.i1}@model.setter''',
                 (
                     f'''{self.i1}def model(self, data: Union'''
-                    f'''['{self.type_.singular().pascal_case()}Model', dict]) -> None:'''
+                    f'''['{self.type_.singular().pascal_case()}Model', dict]):'''
                 ),
                 f'''{self.i2}"""Create model using the provided data."""''',
                 f'''{self.i2}if isinstance(data, type(self.model)):''',
@@ -360,7 +360,7 @@ class GenerateObjectABC(GenerateABC, ABC):
     ) -> str:
         """Return the method code.
 
-        def stage_artifact(self, **kwargs) -> None:
+        def stage_artifact(self, **kwargs):
             '''Stage an Artifact on the object.
 
             ...
@@ -393,7 +393,7 @@ class GenerateObjectABC(GenerateABC, ABC):
                 (
                     f'''{self.i1}def stage_{model_type.singular()}(self, '''
                     f'''data: Union[dict, 'ObjectABC', '{model_import_data.get('model_class')}'''
-                    f'''']) -> None:'''
+                    f'''']):'''
                 ),
                 f'''{self.i2}"""Stage {type_.singular()} on the object."""''',
                 f'''{self.i2}if isinstance(data, ObjectABC):''',
@@ -419,7 +419,7 @@ class GenerateObjectABC(GenerateABC, ABC):
         self.requirements['standard library'].append({'module': 'typing', 'imports': ['Optional']})
         return '\n'.join(
             [
-                f'''{self.i1}def remove(self, params: Optional[dict] = None) -> None:''',
+                f'''{self.i1}def remove(self, params: Optional[dict] = None):''',
                 f'''{self.i2}"""Remove a nested object."""''',
                 f'''{self.i2}method = \'PUT\'''',
                 f'''{self.i2}unique_id = self._calculate_unique_id()''',
@@ -463,7 +463,7 @@ class GenerateObjectABC(GenerateABC, ABC):
 
         def stage_assignee(
             self, type: str, data: Union[dict, 'ObjectABC', 'ArtifactModel']
-        ) -> None:
+        ):
             '''Stage artifact on the object.'''
             if isinstance(data, ObjectABC):
                 data = data.model
@@ -491,7 +491,7 @@ class GenerateObjectABC(GenerateABC, ABC):
                 f'''{self.i1}# pylint: disable=redefined-builtin''',
                 (
                     f'''{self.i1}def stage_assignee(self, type: str, data: '''
-                    f'''Union[dict, 'ObjectABC', 'ArtifactModel']) -> None:'''
+                    f'''Union[dict, 'ObjectABC', 'ArtifactModel']):'''
                 ),
                 f'''{self.i2}"""Stage artifact on the object."""''',
                 f'''{self.i2}if isinstance(data, ObjectABC):''',

--- a/tcex/api/tc/v3/artifact_types/artifact_type.py
+++ b/tcex/api/tc/v3/artifact_types/artifact_type.py
@@ -26,7 +26,7 @@ class ArtifactTypes(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -52,7 +52,7 @@ class ArtifactTypes(ObjectCollectionABC):
 class ArtifactType(ObjectABC):
     """ArtifactTypes Object."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -73,7 +73,7 @@ class ArtifactType(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['ArtifactTypeModel', dict]) -> None:
+    def model(self, data: Union['ArtifactTypeModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/artifact_types/artifact_type_filter.py
+++ b/tcex/api/tc/v3/artifact_types/artifact_type_filter.py
@@ -16,7 +16,7 @@ class ArtifactTypeFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.ARTIFACT_TYPES.value
 
-    def active(self, operator: Enum, active: bool) -> None:
+    def active(self, operator: Enum, active: bool):
         """Filter Active based on **active** keyword.
 
         Args:
@@ -25,7 +25,7 @@ class ArtifactTypeFilter(FilterABC):
         """
         self._tql.add_filter('active', operator, active, TqlType.BOOLEAN)
 
-    def data_type(self, operator: Enum, data_type: str) -> None:
+    def data_type(self, operator: Enum, data_type: str):
         """Filter Data Type based on **dataType** keyword.
 
         Args:
@@ -34,7 +34,7 @@ class ArtifactTypeFilter(FilterABC):
         """
         self._tql.add_filter('dataType', operator, data_type, TqlType.STRING)
 
-    def description(self, operator: Enum, description: str) -> None:
+    def description(self, operator: Enum, description: str):
         """Filter Description based on **description** keyword.
 
         Args:
@@ -43,7 +43,7 @@ class ArtifactTypeFilter(FilterABC):
         """
         self._tql.add_filter('description', operator, description, TqlType.STRING)
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -52,7 +52,7 @@ class ArtifactTypeFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def intel_type(self, operator: Enum, intel_type: str) -> None:
+    def intel_type(self, operator: Enum, intel_type: str):
         """Filter Intel Type based on **intelType** keyword.
 
         Args:
@@ -61,7 +61,7 @@ class ArtifactTypeFilter(FilterABC):
         """
         self._tql.add_filter('intelType', operator, intel_type, TqlType.STRING)
 
-    def managed(self, operator: Enum, managed: bool) -> None:
+    def managed(self, operator: Enum, managed: bool):
         """Filter Managed based on **managed** keyword.
 
         Args:
@@ -70,7 +70,7 @@ class ArtifactTypeFilter(FilterABC):
         """
         self._tql.add_filter('managed', operator, managed, TqlType.BOOLEAN)
 
-    def name(self, operator: Enum, name: str) -> None:
+    def name(self, operator: Enum, name: str):
         """Filter Name based on **name** keyword.
 
         Args:

--- a/tcex/api/tc/v3/artifacts/artifact.py
+++ b/tcex/api/tc/v3/artifacts/artifact.py
@@ -35,7 +35,7 @@ class Artifacts(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -81,7 +81,7 @@ class Artifact(ObjectABC):
         type (str, kwargs): The **type** for the Artifact.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -102,7 +102,7 @@ class Artifact(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['ArtifactModel', dict]) -> None:
+    def model(self, data: Union['ArtifactModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change
@@ -144,7 +144,7 @@ class Artifact(ObjectABC):
 
         yield from self._iterate_over_sublist(Notes)
 
-    def stage_associated_group(self, data: Union[dict, 'ObjectABC', 'GroupModel']) -> None:
+    def stage_associated_group(self, data: Union[dict, 'ObjectABC', 'GroupModel']):
         """Stage group on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -156,7 +156,7 @@ class Artifact(ObjectABC):
         data._staged = True
         self.model.associated_groups.data.append(data)
 
-    def stage_associated_indicator(self, data: Union[dict, 'ObjectABC', 'IndicatorModel']) -> None:
+    def stage_associated_indicator(self, data: Union[dict, 'ObjectABC', 'IndicatorModel']):
         """Stage indicator on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -168,7 +168,7 @@ class Artifact(ObjectABC):
         data._staged = True
         self.model.associated_indicators.data.append(data)
 
-    def stage_note(self, data: Union[dict, 'ObjectABC', 'NoteModel']) -> None:
+    def stage_note(self, data: Union[dict, 'ObjectABC', 'NoteModel']):
         """Stage note on the object."""
         if isinstance(data, ObjectABC):
             data = data.model

--- a/tcex/api/tc/v3/artifacts/artifact_filter.py
+++ b/tcex/api/tc/v3/artifacts/artifact_filter.py
@@ -18,7 +18,7 @@ class ArtifactFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.ARTIFACTS.value
 
-    def analytics_score(self, operator: Enum, analytics_score: int) -> None:
+    def analytics_score(self, operator: Enum, analytics_score: int):
         """Filter Analytics Score based on **analyticsScore** keyword.
 
         Args:
@@ -27,7 +27,7 @@ class ArtifactFilter(FilterABC):
         """
         self._tql.add_filter('analyticsScore', operator, analytics_score, TqlType.INTEGER)
 
-    def case_id(self, operator: Enum, case_id: int) -> None:
+    def case_id(self, operator: Enum, case_id: int):
         """Filter Case ID based on **caseId** keyword.
 
         Args:
@@ -36,7 +36,7 @@ class ArtifactFilter(FilterABC):
         """
         self._tql.add_filter('caseId', operator, case_id, TqlType.INTEGER)
 
-    def date_added(self, operator: Enum, date_added: str) -> None:
+    def date_added(self, operator: Enum, date_added: str):
         """Filter Date Added based on **dateAdded** keyword.
 
         Args:
@@ -96,7 +96,7 @@ class ArtifactFilter(FilterABC):
         self._tql.add_filter('hasTask', TqlOperator.EQ, tasks, TqlType.SUB_QUERY)
         return tasks
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -105,7 +105,7 @@ class ArtifactFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def indicator_active(self, operator: Enum, indicator_active: bool) -> None:
+    def indicator_active(self, operator: Enum, indicator_active: bool):
         """Filter Active Status based on **indicatorActive** keyword.
 
         Args:
@@ -114,7 +114,7 @@ class ArtifactFilter(FilterABC):
         """
         self._tql.add_filter('indicatorActive', operator, indicator_active, TqlType.BOOLEAN)
 
-    def note_id(self, operator: Enum, note_id: int) -> None:
+    def note_id(self, operator: Enum, note_id: int):
         """Filter Note ID based on **noteId** keyword.
 
         Args:
@@ -123,7 +123,7 @@ class ArtifactFilter(FilterABC):
         """
         self._tql.add_filter('noteId', operator, note_id, TqlType.INTEGER)
 
-    def source(self, operator: Enum, source: str) -> None:
+    def source(self, operator: Enum, source: str):
         """Filter Source based on **source** keyword.
 
         Args:
@@ -132,7 +132,7 @@ class ArtifactFilter(FilterABC):
         """
         self._tql.add_filter('source', operator, source, TqlType.STRING)
 
-    def summary(self, operator: Enum, summary: str) -> None:
+    def summary(self, operator: Enum, summary: str):
         """Filter Summary based on **summary** keyword.
 
         Args:
@@ -141,7 +141,7 @@ class ArtifactFilter(FilterABC):
         """
         self._tql.add_filter('summary', operator, summary, TqlType.STRING)
 
-    def task_id(self, operator: Enum, task_id: int) -> None:
+    def task_id(self, operator: Enum, task_id: int):
         """Filter Task ID based on **taskId** keyword.
 
         Args:
@@ -150,7 +150,7 @@ class ArtifactFilter(FilterABC):
         """
         self._tql.add_filter('taskId', operator, task_id, TqlType.INTEGER)
 
-    def type(self, operator: Enum, type: str) -> None:  # pylint: disable=redefined-builtin
+    def type(self, operator: Enum, type: str):  # pylint: disable=redefined-builtin
         """Filter typeName based on **type** keyword.
 
         Args:
@@ -159,7 +159,7 @@ class ArtifactFilter(FilterABC):
         """
         self._tql.add_filter('type', operator, type, TqlType.STRING)
 
-    def type_name(self, operator: Enum, type_name: str) -> None:
+    def type_name(self, operator: Enum, type_name: str):
         """Filter typeName based on **typeName** keyword.
 
         Args:

--- a/tcex/api/tc/v3/attribute_types/attribute_type.py
+++ b/tcex/api/tc/v3/attribute_types/attribute_type.py
@@ -29,7 +29,7 @@ class AttributeTypes(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -55,7 +55,7 @@ class AttributeTypes(ObjectCollectionABC):
 class AttributeType(ObjectABC):
     """AttributeTypes Object."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -76,7 +76,7 @@ class AttributeType(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['AttributeTypeModel', dict]) -> None:
+    def model(self, data: Union['AttributeTypeModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/attribute_types/attribute_type_filter.py
+++ b/tcex/api/tc/v3/attribute_types/attribute_type_filter.py
@@ -16,7 +16,7 @@ class AttributeTypeFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.ATTRIBUTE_TYPES.value
 
-    def associated_type(self, operator: Enum, associated_type: str) -> None:
+    def associated_type(self, operator: Enum, associated_type: str):
         """Filter Associated Type based on **associatedType** keyword.
 
         Args:
@@ -25,7 +25,7 @@ class AttributeTypeFilter(FilterABC):
         """
         self._tql.add_filter('associatedType', operator, associated_type, TqlType.STRING)
 
-    def description(self, operator: Enum, description: str) -> None:
+    def description(self, operator: Enum, description: str):
         """Filter Description based on **description** keyword.
 
         Args:
@@ -34,7 +34,7 @@ class AttributeTypeFilter(FilterABC):
         """
         self._tql.add_filter('description', operator, description, TqlType.STRING)
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -43,7 +43,7 @@ class AttributeTypeFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def maxsize(self, operator: Enum, maxsize: int) -> None:
+    def maxsize(self, operator: Enum, maxsize: int):
         """Filter Maxsize based on **maxsize** keyword.
 
         Args:
@@ -52,7 +52,7 @@ class AttributeTypeFilter(FilterABC):
         """
         self._tql.add_filter('maxsize', operator, maxsize, TqlType.INTEGER)
 
-    def name(self, operator: Enum, name: str) -> None:
+    def name(self, operator: Enum, name: str):
         """Filter Name based on **name** keyword.
 
         Args:
@@ -61,7 +61,7 @@ class AttributeTypeFilter(FilterABC):
         """
         self._tql.add_filter('name', operator, name, TqlType.STRING)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -70,7 +70,7 @@ class AttributeTypeFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -79,7 +79,7 @@ class AttributeTypeFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def system(self, operator: Enum, system: bool) -> None:
+    def system(self, operator: Enum, system: bool):
         """Filter SystemLevel based on **system** keyword.
 
         Args:

--- a/tcex/api/tc/v3/case_attributes/case_attribute.py
+++ b/tcex/api/tc/v3/case_attributes/case_attribute.py
@@ -29,7 +29,7 @@ class CaseAttributes(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -64,7 +64,7 @@ class CaseAttribute(ObjectABC):
         value (str, kwargs): Attribute value.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -85,7 +85,7 @@ class CaseAttribute(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['CaseAttributeModel', dict]) -> None:
+    def model(self, data: Union['CaseAttributeModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/case_attributes/case_attribute_filter.py
+++ b/tcex/api/tc/v3/case_attributes/case_attribute_filter.py
@@ -18,7 +18,7 @@ class CaseAttributeFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.CASE_ATTRIBUTES.value
 
-    def case_id(self, operator: Enum, case_id: int) -> None:
+    def case_id(self, operator: Enum, case_id: int):
         """Filter Workflow ID based on **caseId** keyword.
 
         Args:
@@ -27,7 +27,7 @@ class CaseAttributeFilter(FilterABC):
         """
         self._tql.add_filter('caseId', operator, case_id, TqlType.INTEGER)
 
-    def date_added(self, operator: Enum, date_added: str) -> None:
+    def date_added(self, operator: Enum, date_added: str):
         """Filter Date Added based on **dateAdded** keyword.
 
         Args:
@@ -37,7 +37,7 @@ class CaseAttributeFilter(FilterABC):
         date_added = self.utils.any_to_datetime(date_added).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateAdded', operator, date_added, TqlType.STRING)
 
-    def date_val(self, operator: Enum, date_val: str) -> None:
+    def date_val(self, operator: Enum, date_val: str):
         """Filter Date based on **dateVal** keyword.
 
         Args:
@@ -47,7 +47,7 @@ class CaseAttributeFilter(FilterABC):
         date_val = self.utils.any_to_datetime(date_val).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateVal', operator, date_val, TqlType.STRING)
 
-    def displayed(self, operator: Enum, displayed: bool) -> None:
+    def displayed(self, operator: Enum, displayed: bool):
         """Filter Displayed based on **displayed** keyword.
 
         Args:
@@ -66,7 +66,7 @@ class CaseAttributeFilter(FilterABC):
         self._tql.add_filter('hasCase', TqlOperator.EQ, cases, TqlType.SUB_QUERY)
         return cases
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -75,7 +75,7 @@ class CaseAttributeFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def int_val(self, operator: Enum, int_val: int) -> None:
+    def int_val(self, operator: Enum, int_val: int):
         """Filter Integer Value based on **intVal** keyword.
 
         Args:
@@ -84,7 +84,7 @@ class CaseAttributeFilter(FilterABC):
         """
         self._tql.add_filter('intVal', operator, int_val, TqlType.INTEGER)
 
-    def last_modified(self, operator: Enum, last_modified: str) -> None:
+    def last_modified(self, operator: Enum, last_modified: str):
         """Filter Last Modified based on **lastModified** keyword.
 
         Args:
@@ -94,7 +94,7 @@ class CaseAttributeFilter(FilterABC):
         last_modified = self.utils.any_to_datetime(last_modified).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('lastModified', operator, last_modified, TqlType.STRING)
 
-    def max_size(self, operator: Enum, max_size: int) -> None:
+    def max_size(self, operator: Enum, max_size: int):
         """Filter Max Size based on **maxSize** keyword.
 
         Args:
@@ -103,7 +103,7 @@ class CaseAttributeFilter(FilterABC):
         """
         self._tql.add_filter('maxSize', operator, max_size, TqlType.INTEGER)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -112,7 +112,7 @@ class CaseAttributeFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -121,7 +121,7 @@ class CaseAttributeFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def source(self, operator: Enum, source: str) -> None:
+    def source(self, operator: Enum, source: str):
         """Filter Source based on **source** keyword.
 
         Args:
@@ -130,7 +130,7 @@ class CaseAttributeFilter(FilterABC):
         """
         self._tql.add_filter('source', operator, source, TqlType.STRING)
 
-    def text(self, operator: Enum, text: str) -> None:
+    def text(self, operator: Enum, text: str):
         """Filter Text based on **text** keyword.
 
         Args:
@@ -139,7 +139,7 @@ class CaseAttributeFilter(FilterABC):
         """
         self._tql.add_filter('text', operator, text, TqlType.STRING)
 
-    def type(self, operator: Enum, type: int) -> None:  # pylint: disable=redefined-builtin
+    def type(self, operator: Enum, type: int):  # pylint: disable=redefined-builtin
         """Filter Type ID based on **type** keyword.
 
         Args:
@@ -148,7 +148,7 @@ class CaseAttributeFilter(FilterABC):
         """
         self._tql.add_filter('type', operator, type, TqlType.INTEGER)
 
-    def type_name(self, operator: Enum, type_name: str) -> None:
+    def type_name(self, operator: Enum, type_name: str):
         """Filter Type Name based on **typeName** keyword.
 
         Args:
@@ -157,7 +157,7 @@ class CaseAttributeFilter(FilterABC):
         """
         self._tql.add_filter('typeName', operator, type_name, TqlType.STRING)
 
-    def user(self, operator: Enum, user: str) -> None:
+    def user(self, operator: Enum, user: str):
         """Filter User based on **user** keyword.
 
         Args:

--- a/tcex/api/tc/v3/case_management/case_management.py
+++ b/tcex/api/tc/v3/case_management/case_management.py
@@ -14,7 +14,7 @@ class CaseManagement:
         session: An configured instance of request.Session with TC API Auth.
     """
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: Session):
         """Initialize Class properties."""
         self.session = session
 
@@ -99,7 +99,7 @@ class CaseManagement:
         """
         return ArtifactTypes(session=self.session, **kwargs)
 
-    def assignee(self, **kwargs) -> AssigneeModel:
+    def assignee(self, **kwargs) -> 'AssigneeModel':
         """Return a instance of Assignee object.
 
         For User type the user_name or id fields is required and
@@ -358,7 +358,7 @@ class CaseManagement:
         return Tasks(session=self.session, **kwargs)
 
     # @staticmethod
-    # def user(self, **kwargs) -> User:
+    # def user(self, **kwargs) -> 'User':
     #     """Return a instance of User object.
     #
     #     Args:
@@ -372,7 +372,7 @@ class CaseManagement:
     #     return User(session=self.session, **kwargs)
 
     # @staticmethod
-    # def users(users) -> Users:
+    # def users(users) -> 'Users':
     #     """Sub class of the Cases object. Used to map the users to.
 
     #     Args:

--- a/tcex/api/tc/v3/cases/case.py
+++ b/tcex/api/tc/v3/cases/case.py
@@ -45,7 +45,7 @@ class Cases(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -101,7 +101,7 @@ class Case(ObjectABC):
         xid (str, kwargs): The **xid** for the Case.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -122,7 +122,7 @@ class Case(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['CaseModel', dict]) -> None:
+    def model(self, data: Union['CaseModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change
@@ -205,7 +205,7 @@ class Case(ObjectABC):
 
         yield from self._iterate_over_sublist(Tasks)
 
-    def stage_artifact(self, data: Union[dict, 'ObjectABC', 'ArtifactModel']) -> None:
+    def stage_artifact(self, data: Union[dict, 'ObjectABC', 'ArtifactModel']):
         """Stage artifact on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -218,7 +218,7 @@ class Case(ObjectABC):
         self.model.artifacts.data.append(data)
 
     # pylint: disable=redefined-builtin
-    def stage_assignee(self, type: str, data: Union[dict, 'ObjectABC', 'ArtifactModel']) -> None:
+    def stage_assignee(self, type: str, data: Union[dict, 'ObjectABC', 'ArtifactModel']):
         """Stage artifact on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -234,7 +234,7 @@ class Case(ObjectABC):
         self.model.assignee.type = type
         self.model.assignee.data = data
 
-    def stage_associated_case(self, data: Union[dict, 'ObjectABC', 'CaseModel']) -> None:
+    def stage_associated_case(self, data: Union[dict, 'ObjectABC', 'CaseModel']):
         """Stage case on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -246,7 +246,7 @@ class Case(ObjectABC):
         data._staged = True
         self.model.associated_cases.data.append(data)
 
-    def stage_associated_group(self, data: Union[dict, 'ObjectABC', 'GroupModel']) -> None:
+    def stage_associated_group(self, data: Union[dict, 'ObjectABC', 'GroupModel']):
         """Stage group on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -258,7 +258,7 @@ class Case(ObjectABC):
         data._staged = True
         self.model.associated_groups.data.append(data)
 
-    def stage_associated_indicator(self, data: Union[dict, 'ObjectABC', 'IndicatorModel']) -> None:
+    def stage_associated_indicator(self, data: Union[dict, 'ObjectABC', 'IndicatorModel']):
         """Stage indicator on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -270,7 +270,7 @@ class Case(ObjectABC):
         data._staged = True
         self.model.associated_indicators.data.append(data)
 
-    def stage_attribute(self, data: Union[dict, 'ObjectABC', 'CaseAttributeModel']) -> None:
+    def stage_attribute(self, data: Union[dict, 'ObjectABC', 'CaseAttributeModel']):
         """Stage attribute on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -282,7 +282,7 @@ class Case(ObjectABC):
         data._staged = True
         self.model.attributes.data.append(data)
 
-    def stage_note(self, data: Union[dict, 'ObjectABC', 'NoteModel']) -> None:
+    def stage_note(self, data: Union[dict, 'ObjectABC', 'NoteModel']):
         """Stage note on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -294,7 +294,7 @@ class Case(ObjectABC):
         data._staged = True
         self.model.notes.data.append(data)
 
-    def stage_tag(self, data: Union[dict, 'ObjectABC', 'TagModel']) -> None:
+    def stage_tag(self, data: Union[dict, 'ObjectABC', 'TagModel']):
         """Stage tag on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -306,7 +306,7 @@ class Case(ObjectABC):
         data._staged = True
         self.model.tags.data.append(data)
 
-    def stage_task(self, data: Union[dict, 'ObjectABC', 'TaskModel']) -> None:
+    def stage_task(self, data: Union[dict, 'ObjectABC', 'TaskModel']):
         """Stage task on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -318,7 +318,7 @@ class Case(ObjectABC):
         data._staged = True
         self.model.tasks.data.append(data)
 
-    def stage_user_access(self, data: Union[dict, 'ObjectABC', 'UserModel']) -> None:
+    def stage_user_access(self, data: Union[dict, 'ObjectABC', 'UserModel']):
         """Stage user on the object."""
         if isinstance(data, ObjectABC):
             data = data.model

--- a/tcex/api/tc/v3/cases/case_filter.py
+++ b/tcex/api/tc/v3/cases/case_filter.py
@@ -18,7 +18,7 @@ class CaseFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.CASES.value
 
-    def assigned_to_user_or_group(self, operator: Enum, assigned_to_user_or_group: str) -> None:
+    def assigned_to_user_or_group(self, operator: Enum, assigned_to_user_or_group: str):
         """Filter Assigned To User or Group based on **assignedToUserOrGroup** keyword.
 
         Args:
@@ -29,7 +29,7 @@ class CaseFilter(FilterABC):
             'assignedToUserOrGroup', operator, assigned_to_user_or_group, TqlType.STRING
         )
 
-    def assignee_name(self, operator: Enum, assignee_name: str) -> None:
+    def assignee_name(self, operator: Enum, assignee_name: str):
         """Filter Assignee based on **assigneeName** keyword.
 
         Args:
@@ -38,7 +38,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('assigneeName', operator, assignee_name, TqlType.STRING)
 
-    def attribute(self, operator: Enum, attribute: str) -> None:
+    def attribute(self, operator: Enum, attribute: str):
         """Filter attribute based on **attribute** keyword.
 
         Args:
@@ -47,7 +47,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('attribute', operator, attribute, TqlType.STRING)
 
-    def case_close_time(self, operator: Enum, case_close_time: str) -> None:
+    def case_close_time(self, operator: Enum, case_close_time: str):
         """Filter Case Close Time based on **caseCloseTime** keyword.
 
         Args:
@@ -57,7 +57,7 @@ class CaseFilter(FilterABC):
         case_close_time = self.utils.any_to_datetime(case_close_time).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('caseCloseTime', operator, case_close_time, TqlType.STRING)
 
-    def case_close_user(self, operator: Enum, case_close_user: str) -> None:
+    def case_close_user(self, operator: Enum, case_close_user: str):
         """Filter Case Close User based on **caseCloseUser** keyword.
 
         Args:
@@ -66,7 +66,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('caseCloseUser', operator, case_close_user, TqlType.STRING)
 
-    def case_detection_time(self, operator: Enum, case_detection_time: str) -> None:
+    def case_detection_time(self, operator: Enum, case_detection_time: str):
         """Filter Case Detection Time based on **caseDetectionTime** keyword.
 
         Args:
@@ -78,7 +78,7 @@ class CaseFilter(FilterABC):
         )
         self._tql.add_filter('caseDetectionTime', operator, case_detection_time, TqlType.STRING)
 
-    def case_detection_user(self, operator: Enum, case_detection_user: str) -> None:
+    def case_detection_user(self, operator: Enum, case_detection_user: str):
         """Filter Case Detection User based on **caseDetectionUser** keyword.
 
         Args:
@@ -87,7 +87,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('caseDetectionUser', operator, case_detection_user, TqlType.STRING)
 
-    def case_occurrence_time(self, operator: Enum, case_occurrence_time: str) -> None:
+    def case_occurrence_time(self, operator: Enum, case_occurrence_time: str):
         """Filter Case Occurrence Time based on **caseOccurrenceTime** keyword.
 
         Args:
@@ -99,7 +99,7 @@ class CaseFilter(FilterABC):
         )
         self._tql.add_filter('caseOccurrenceTime', operator, case_occurrence_time, TqlType.STRING)
 
-    def case_occurrence_user(self, operator: Enum, case_occurrence_user: str) -> None:
+    def case_occurrence_user(self, operator: Enum, case_occurrence_user: str):
         """Filter Case Occurrence User based on **caseOccurrenceUser** keyword.
 
         Args:
@@ -108,7 +108,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('caseOccurrenceUser', operator, case_occurrence_user, TqlType.STRING)
 
-    def case_open_time(self, operator: Enum, case_open_time: str) -> None:
+    def case_open_time(self, operator: Enum, case_open_time: str):
         """Filter Case Open Time based on **caseOpenTime** keyword.
 
         Args:
@@ -118,7 +118,7 @@ class CaseFilter(FilterABC):
         case_open_time = self.utils.any_to_datetime(case_open_time).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('caseOpenTime', operator, case_open_time, TqlType.STRING)
 
-    def case_open_user(self, operator: Enum, case_open_user: str) -> None:
+    def case_open_user(self, operator: Enum, case_open_user: str):
         """Filter Case Opening User based on **caseOpenUser** keyword.
 
         Args:
@@ -127,7 +127,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('caseOpenUser', operator, case_open_user, TqlType.STRING)
 
-    def created_by(self, operator: Enum, created_by: str) -> None:
+    def created_by(self, operator: Enum, created_by: str):
         """Filter Creator based on **createdBy** keyword.
 
         Args:
@@ -136,7 +136,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('createdBy', operator, created_by, TqlType.STRING)
 
-    def created_by_id(self, operator: Enum, created_by_id: int) -> None:
+    def created_by_id(self, operator: Enum, created_by_id: int):
         """Filter Creator ID based on **createdById** keyword.
 
         Args:
@@ -145,7 +145,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('createdById', operator, created_by_id, TqlType.INTEGER)
 
-    def date_added(self, operator: Enum, date_added: str) -> None:
+    def date_added(self, operator: Enum, date_added: str):
         """Filter Date Added based on **dateAdded** keyword.
 
         Args:
@@ -155,7 +155,7 @@ class CaseFilter(FilterABC):
         date_added = self.utils.any_to_datetime(date_added).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateAdded', operator, date_added, TqlType.STRING)
 
-    def description(self, operator: Enum, description: str) -> None:
+    def description(self, operator: Enum, description: str):
         """Filter Description based on **description** keyword.
 
         Args:
@@ -231,7 +231,7 @@ class CaseFilter(FilterABC):
         self._tql.add_filter('hasTask', TqlOperator.EQ, tasks, TqlType.SUB_QUERY)
         return tasks
 
-    def has_workflow_template(self, operator: Enum, has_workflow_template: int) -> None:
+    def has_workflow_template(self, operator: Enum, has_workflow_template: int):
         """Filter Associated Workflow Template based on **hasWorkflowTemplate** keyword.
 
         Args:
@@ -242,7 +242,7 @@ class CaseFilter(FilterABC):
             'hasWorkflowTemplate', operator, has_workflow_template, TqlType.INTEGER
         )
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -251,7 +251,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def id_as_string(self, operator: Enum, id_as_string: str) -> None:
+    def id_as_string(self, operator: Enum, id_as_string: str):
         """Filter ID As String based on **idAsString** keyword.
 
         Args:
@@ -260,7 +260,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('idAsString', operator, id_as_string, TqlType.STRING)
 
-    def name(self, operator: Enum, name: str) -> None:
+    def name(self, operator: Enum, name: str):
         """Filter Name based on **name** keyword.
 
         Args:
@@ -269,7 +269,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('name', operator, name, TqlType.STRING)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -278,7 +278,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -287,7 +287,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def resolution(self, operator: Enum, resolution: str) -> None:
+    def resolution(self, operator: Enum, resolution: str):
         """Filter Resolution based on **resolution** keyword.
 
         Args:
@@ -296,7 +296,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('resolution', operator, resolution, TqlType.STRING)
 
-    def severity(self, operator: Enum, severity: str) -> None:
+    def severity(self, operator: Enum, severity: str):
         """Filter Severity based on **severity** keyword.
 
         Args:
@@ -305,7 +305,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('severity', operator, severity, TqlType.STRING)
 
-    def status(self, operator: Enum, status: str) -> None:
+    def status(self, operator: Enum, status: str):
         """Filter Status based on **status** keyword.
 
         Args:
@@ -314,7 +314,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('status', operator, status, TqlType.STRING)
 
-    def tag(self, operator: Enum, tag: str) -> None:
+    def tag(self, operator: Enum, tag: str):
         """Filter Tag based on **tag** keyword.
 
         Args:
@@ -323,7 +323,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('tag', operator, tag, TqlType.STRING)
 
-    def target_id(self, operator: Enum, target_id: int) -> None:
+    def target_id(self, operator: Enum, target_id: int):
         """Filter Assignee ID based on **targetId** keyword.
 
         Args:
@@ -332,7 +332,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('targetId', operator, target_id, TqlType.INTEGER)
 
-    def target_type(self, operator: Enum, target_type: str) -> None:
+    def target_type(self, operator: Enum, target_type: str):
         """Filter Target Type based on **targetType** keyword.
 
         Args:
@@ -341,7 +341,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('targetType', operator, target_type, TqlType.STRING)
 
-    def type_name(self, operator: Enum, type_name: str) -> None:
+    def type_name(self, operator: Enum, type_name: str):
         """Filter Name based on **typeName** keyword.
 
         Args:
@@ -350,7 +350,7 @@ class CaseFilter(FilterABC):
         """
         self._tql.add_filter('typeName', operator, type_name, TqlType.STRING)
 
-    def xid(self, operator: Enum, xid: str) -> None:
+    def xid(self, operator: Enum, xid: str):
         """Filter XID based on **xid** keyword.
 
         Args:

--- a/tcex/api/tc/v3/filter_abc.py
+++ b/tcex/api/tc/v3/filter_abc.py
@@ -42,7 +42,7 @@ class FilterABC(ABC):
         return self._tql
 
     @tql.setter
-    def tql(self, tql: str) -> None:
+    def tql(self, tql: str):
         """Filter objects based on TQL expression.
 
         Args:

--- a/tcex/api/tc/v3/group_attributes/group_attribute.py
+++ b/tcex/api/tc/v3/group_attributes/group_attribute.py
@@ -29,7 +29,7 @@ class GroupAttributes(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -64,7 +64,7 @@ class GroupAttribute(ObjectABC):
         value (str, kwargs): Attribute value.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -85,7 +85,7 @@ class GroupAttribute(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['GroupAttributeModel', dict]) -> None:
+    def model(self, data: Union['GroupAttributeModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/group_attributes/group_attribute_filter.py
+++ b/tcex/api/tc/v3/group_attributes/group_attribute_filter.py
@@ -18,7 +18,7 @@ class GroupAttributeFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.GROUP_ATTRIBUTES.value
 
-    def date_added(self, operator: Enum, date_added: str) -> None:
+    def date_added(self, operator: Enum, date_added: str):
         """Filter Date Added based on **dateAdded** keyword.
 
         Args:
@@ -28,7 +28,7 @@ class GroupAttributeFilter(FilterABC):
         date_added = self.utils.any_to_datetime(date_added).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateAdded', operator, date_added, TqlType.STRING)
 
-    def date_val(self, operator: Enum, date_val: str) -> None:
+    def date_val(self, operator: Enum, date_val: str):
         """Filter Date based on **dateVal** keyword.
 
         Args:
@@ -38,7 +38,7 @@ class GroupAttributeFilter(FilterABC):
         date_val = self.utils.any_to_datetime(date_val).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateVal', operator, date_val, TqlType.STRING)
 
-    def displayed(self, operator: Enum, displayed: bool) -> None:
+    def displayed(self, operator: Enum, displayed: bool):
         """Filter Displayed based on **displayed** keyword.
 
         Args:
@@ -47,7 +47,7 @@ class GroupAttributeFilter(FilterABC):
         """
         self._tql.add_filter('displayed', operator, displayed, TqlType.BOOLEAN)
 
-    def group_id(self, operator: Enum, group_id: int) -> None:
+    def group_id(self, operator: Enum, group_id: int):
         """Filter Group ID based on **groupId** keyword.
 
         Args:
@@ -76,7 +76,7 @@ class GroupAttributeFilter(FilterABC):
         self._tql.add_filter('hasSecurityLabel', TqlOperator.EQ, security_labels, TqlType.SUB_QUERY)
         return security_labels
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -85,7 +85,7 @@ class GroupAttributeFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def int_val(self, operator: Enum, int_val: int) -> None:
+    def int_val(self, operator: Enum, int_val: int):
         """Filter Integer Value based on **intVal** keyword.
 
         Args:
@@ -94,7 +94,7 @@ class GroupAttributeFilter(FilterABC):
         """
         self._tql.add_filter('intVal', operator, int_val, TqlType.INTEGER)
 
-    def last_modified(self, operator: Enum, last_modified: str) -> None:
+    def last_modified(self, operator: Enum, last_modified: str):
         """Filter Last Modified based on **lastModified** keyword.
 
         Args:
@@ -104,7 +104,7 @@ class GroupAttributeFilter(FilterABC):
         last_modified = self.utils.any_to_datetime(last_modified).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('lastModified', operator, last_modified, TqlType.STRING)
 
-    def max_size(self, operator: Enum, max_size: int) -> None:
+    def max_size(self, operator: Enum, max_size: int):
         """Filter Max Size based on **maxSize** keyword.
 
         Args:
@@ -113,7 +113,7 @@ class GroupAttributeFilter(FilterABC):
         """
         self._tql.add_filter('maxSize', operator, max_size, TqlType.INTEGER)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -122,7 +122,7 @@ class GroupAttributeFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -131,7 +131,7 @@ class GroupAttributeFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def source(self, operator: Enum, source: str) -> None:
+    def source(self, operator: Enum, source: str):
         """Filter Source based on **source** keyword.
 
         Args:
@@ -140,7 +140,7 @@ class GroupAttributeFilter(FilterABC):
         """
         self._tql.add_filter('source', operator, source, TqlType.STRING)
 
-    def text(self, operator: Enum, text: str) -> None:
+    def text(self, operator: Enum, text: str):
         """Filter Text based on **text** keyword.
 
         Args:
@@ -149,7 +149,7 @@ class GroupAttributeFilter(FilterABC):
         """
         self._tql.add_filter('text', operator, text, TqlType.STRING)
 
-    def type(self, operator: Enum, type: int) -> None:  # pylint: disable=redefined-builtin
+    def type(self, operator: Enum, type: int):  # pylint: disable=redefined-builtin
         """Filter Type ID based on **type** keyword.
 
         Args:
@@ -158,7 +158,7 @@ class GroupAttributeFilter(FilterABC):
         """
         self._tql.add_filter('type', operator, type, TqlType.INTEGER)
 
-    def type_name(self, operator: Enum, type_name: str) -> None:
+    def type_name(self, operator: Enum, type_name: str):
         """Filter Type Name based on **typeName** keyword.
 
         Args:
@@ -167,7 +167,7 @@ class GroupAttributeFilter(FilterABC):
         """
         self._tql.add_filter('typeName', operator, type_name, TqlType.STRING)
 
-    def user(self, operator: Enum, user: str) -> None:
+    def user(self, operator: Enum, user: str):
         """Filter User based on **user** keyword.
 
         Args:

--- a/tcex/api/tc/v3/groups/group.py
+++ b/tcex/api/tc/v3/groups/group.py
@@ -47,7 +47,7 @@ class Groups(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -111,7 +111,7 @@ class Group(ObjectABC):
         xid (str, kwargs): The xid of the item.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -132,7 +132,7 @@ class Group(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['GroupModel', dict]) -> None:
+    def model(self, data: Union['GroupModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change
@@ -150,7 +150,7 @@ class Group(ObjectABC):
 
         return {'type': type_, 'id': self.model.id, 'value': self.model.name}
 
-    def remove(self, params: Optional[dict] = None) -> None:
+    def remove(self, params: Optional[dict] = None):
         """Remove a nested object."""
         method = 'PUT'
         unique_id = self._calculate_unique_id()
@@ -284,7 +284,7 @@ class Group(ObjectABC):
 
         yield from self._iterate_over_sublist(Tags)
 
-    def stage_associated_case(self, data: Union[dict, 'ObjectABC', 'CaseModel']) -> None:
+    def stage_associated_case(self, data: Union[dict, 'ObjectABC', 'CaseModel']):
         """Stage case on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -296,7 +296,7 @@ class Group(ObjectABC):
         data._staged = True
         self.model.associated_cases.data.append(data)
 
-    def stage_associated_artifact(self, data: Union[dict, 'ObjectABC', 'ArtifactModel']) -> None:
+    def stage_associated_artifact(self, data: Union[dict, 'ObjectABC', 'ArtifactModel']):
         """Stage artifact on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -308,7 +308,7 @@ class Group(ObjectABC):
         data._staged = True
         self.model.associated_artifacts.data.append(data)
 
-    def stage_associated_group(self, data: Union[dict, 'ObjectABC', 'GroupModel']) -> None:
+    def stage_associated_group(self, data: Union[dict, 'ObjectABC', 'GroupModel']):
         """Stage group on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -320,9 +320,7 @@ class Group(ObjectABC):
         data._staged = True
         self.model.associated_groups.data.append(data)
 
-    def stage_associated_victim_asset(
-        self, data: Union[dict, 'ObjectABC', 'VictimAssetModel']
-    ) -> None:
+    def stage_associated_victim_asset(self, data: Union[dict, 'ObjectABC', 'VictimAssetModel']):
         """Stage victim_asset on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -334,7 +332,7 @@ class Group(ObjectABC):
         data._staged = True
         self.model.assets.data.append(data)
 
-    def stage_associated_indicator(self, data: Union[dict, 'ObjectABC', 'IndicatorModel']) -> None:
+    def stage_associated_indicator(self, data: Union[dict, 'ObjectABC', 'IndicatorModel']):
         """Stage indicator on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -346,7 +344,7 @@ class Group(ObjectABC):
         data._staged = True
         self.model.associated_indicators.data.append(data)
 
-    def stage_attribute(self, data: Union[dict, 'ObjectABC', 'GroupAttributeModel']) -> None:
+    def stage_attribute(self, data: Union[dict, 'ObjectABC', 'GroupAttributeModel']):
         """Stage attribute on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -358,7 +356,7 @@ class Group(ObjectABC):
         data._staged = True
         self.model.attributes.data.append(data)
 
-    def stage_security_label(self, data: Union[dict, 'ObjectABC', 'SecurityLabelModel']) -> None:
+    def stage_security_label(self, data: Union[dict, 'ObjectABC', 'SecurityLabelModel']):
         """Stage security_label on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -370,7 +368,7 @@ class Group(ObjectABC):
         data._staged = True
         self.model.security_labels.data.append(data)
 
-    def stage_tag(self, data: Union[dict, 'ObjectABC', 'TagModel']) -> None:
+    def stage_tag(self, data: Union[dict, 'ObjectABC', 'TagModel']):
         """Stage tag on the object."""
         if isinstance(data, ObjectABC):
             data = data.model

--- a/tcex/api/tc/v3/groups/group_filter.py
+++ b/tcex/api/tc/v3/groups/group_filter.py
@@ -18,7 +18,7 @@ class GroupFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.GROUPS.value
 
-    def associated_indicator(self, operator: Enum, associated_indicator: int) -> None:
+    def associated_indicator(self, operator: Enum, associated_indicator: int):
         """Filter associatedIndicator based on **associatedIndicator** keyword.
 
         Args:
@@ -27,7 +27,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('associatedIndicator', operator, associated_indicator, TqlType.INTEGER)
 
-    def attribute(self, operator: Enum, attribute: str) -> None:
+    def attribute(self, operator: Enum, attribute: str):
         """Filter attribute based on **attribute** keyword.
 
         Args:
@@ -36,7 +36,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('attribute', operator, attribute, TqlType.STRING)
 
-    def child_group(self, operator: Enum, child_group: int) -> None:
+    def child_group(self, operator: Enum, child_group: int):
         """Filter childGroup based on **childGroup** keyword.
 
         Args:
@@ -45,7 +45,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('childGroup', operator, child_group, TqlType.INTEGER)
 
-    def created_by(self, operator: Enum, created_by: str) -> None:
+    def created_by(self, operator: Enum, created_by: str):
         """Filter Created By based on **createdBy** keyword.
 
         Args:
@@ -54,7 +54,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('createdBy', operator, created_by, TqlType.STRING)
 
-    def date_added(self, operator: Enum, date_added: str) -> None:
+    def date_added(self, operator: Enum, date_added: str):
         """Filter Date Added based on **dateAdded** keyword.
 
         Args:
@@ -64,7 +64,7 @@ class GroupFilter(FilterABC):
         date_added = self.utils.any_to_datetime(date_added).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateAdded', operator, date_added, TqlType.STRING)
 
-    def document_date_added(self, operator: Enum, document_date_added: str) -> None:
+    def document_date_added(self, operator: Enum, document_date_added: str):
         """Filter Date Added (Document) based on **documentDateAdded** keyword.
 
         Args:
@@ -76,7 +76,7 @@ class GroupFilter(FilterABC):
         )
         self._tql.add_filter('documentDateAdded', operator, document_date_added, TqlType.STRING)
 
-    def document_filename(self, operator: Enum, document_filename: str) -> None:
+    def document_filename(self, operator: Enum, document_filename: str):
         """Filter Filename (Document) based on **documentFilename** keyword.
 
         Args:
@@ -85,7 +85,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('documentFilename', operator, document_filename, TqlType.STRING)
 
-    def document_filesize(self, operator: Enum, document_filesize: int) -> None:
+    def document_filesize(self, operator: Enum, document_filesize: int):
         """Filter File Size (Document) based on **documentFilesize** keyword.
 
         Args:
@@ -94,7 +94,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('documentFilesize', operator, document_filesize, TqlType.INTEGER)
 
-    def document_status(self, operator: Enum, document_status: str) -> None:
+    def document_status(self, operator: Enum, document_status: str):
         """Filter Status (Document) based on **documentStatus** keyword.
 
         Args:
@@ -103,7 +103,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('documentStatus', operator, document_status, TqlType.STRING)
 
-    def document_type(self, operator: Enum, document_type: str) -> None:
+    def document_type(self, operator: Enum, document_type: str):
         """Filter Type (Document) based on **documentType** keyword.
 
         Args:
@@ -112,7 +112,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('documentType', operator, document_type, TqlType.STRING)
 
-    def downvote_count(self, operator: Enum, downvote_count: int) -> None:
+    def downvote_count(self, operator: Enum, downvote_count: int):
         """Filter Downvote Count based on **downvoteCount** keyword.
 
         Args:
@@ -121,7 +121,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('downvoteCount', operator, downvote_count, TqlType.INTEGER)
 
-    def email_date(self, operator: Enum, email_date: str) -> None:
+    def email_date(self, operator: Enum, email_date: str):
         """Filter Date (Email) based on **emailDate** keyword.
 
         Args:
@@ -131,7 +131,7 @@ class GroupFilter(FilterABC):
         email_date = self.utils.any_to_datetime(email_date).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('emailDate', operator, email_date, TqlType.STRING)
 
-    def email_from(self, operator: Enum, email_from: str) -> None:
+    def email_from(self, operator: Enum, email_from: str):
         """Filter From (Email) based on **emailFrom** keyword.
 
         Args:
@@ -140,7 +140,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('emailFrom', operator, email_from, TqlType.STRING)
 
-    def email_score(self, operator: Enum, email_score: int) -> None:
+    def email_score(self, operator: Enum, email_score: int):
         """Filter Score (Email) based on **emailScore** keyword.
 
         Args:
@@ -149,7 +149,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('emailScore', operator, email_score, TqlType.INTEGER)
 
-    def email_score_includes_body(self, operator: Enum, email_score_includes_body: bool) -> None:
+    def email_score_includes_body(self, operator: Enum, email_score_includes_body: bool):
         """Filter Score Includes Body (Email) based on **emailScoreIncludesBody** keyword.
 
         Args:
@@ -161,7 +161,7 @@ class GroupFilter(FilterABC):
             'emailScoreIncludesBody', operator, email_score_includes_body, TqlType.BOOLEAN
         )
 
-    def email_subject(self, operator: Enum, email_subject: str) -> None:
+    def email_subject(self, operator: Enum, email_subject: str):
         """Filter Subject (Email) based on **emailSubject** keyword.
 
         Args:
@@ -170,7 +170,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('emailSubject', operator, email_subject, TqlType.STRING)
 
-    def event_date(self, operator: Enum, event_date: str) -> None:
+    def event_date(self, operator: Enum, event_date: str):
         """Filter Event Date based on **eventDate** keyword.
 
         Args:
@@ -267,7 +267,7 @@ class GroupFilter(FilterABC):
         self._tql.add_filter('hasVictimAsset', TqlOperator.EQ, victim_assets, TqlType.SUB_QUERY)
         return victim_assets
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -276,7 +276,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def is_group(self, operator: Enum, is_group: bool) -> None:
+    def is_group(self, operator: Enum, is_group: bool):
         """Filter isGroup based on **isGroup** keyword.
 
         Args:
@@ -285,7 +285,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('isGroup', operator, is_group, TqlType.BOOLEAN)
 
-    def last_modified(self, operator: Enum, last_modified: str) -> None:
+    def last_modified(self, operator: Enum, last_modified: str):
         """Filter Last Modified based on **lastModified** keyword.
 
         Args:
@@ -295,7 +295,7 @@ class GroupFilter(FilterABC):
         last_modified = self.utils.any_to_datetime(last_modified).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('lastModified', operator, last_modified, TqlType.STRING)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -304,7 +304,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -313,7 +313,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def parent_group(self, operator: Enum, parent_group: int) -> None:
+    def parent_group(self, operator: Enum, parent_group: int):
         """Filter parentGroup based on **parentGroup** keyword.
 
         Args:
@@ -322,7 +322,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('parentGroup', operator, parent_group, TqlType.INTEGER)
 
-    def security_label(self, operator: Enum, security_label: str) -> None:
+    def security_label(self, operator: Enum, security_label: str):
         """Filter Security Label based on **securityLabel** keyword.
 
         Args:
@@ -331,7 +331,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('securityLabel', operator, security_label, TqlType.STRING)
 
-    def signature_date_added(self, operator: Enum, signature_date_added: str) -> None:
+    def signature_date_added(self, operator: Enum, signature_date_added: str):
         """Filter Date Added (Signature) based on **signatureDateAdded** keyword.
 
         Args:
@@ -343,7 +343,7 @@ class GroupFilter(FilterABC):
         )
         self._tql.add_filter('signatureDateAdded', operator, signature_date_added, TqlType.STRING)
 
-    def signature_filename(self, operator: Enum, signature_filename: str) -> None:
+    def signature_filename(self, operator: Enum, signature_filename: str):
         """Filter Filename (Signature) based on **signatureFilename** keyword.
 
         Args:
@@ -352,7 +352,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('signatureFilename', operator, signature_filename, TqlType.STRING)
 
-    def signature_type(self, operator: Enum, signature_type: str) -> None:
+    def signature_type(self, operator: Enum, signature_type: str):
         """Filter Type (Signature) based on **signatureType** keyword.
 
         Args:
@@ -361,7 +361,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('signatureType', operator, signature_type, TqlType.STRING)
 
-    def status(self, operator: Enum, status: str) -> None:
+    def status(self, operator: Enum, status: str):
         """Filter Status based on **status** keyword.
 
         Args:
@@ -370,7 +370,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('status', operator, status, TqlType.STRING)
 
-    def summary(self, operator: Enum, summary: str) -> None:
+    def summary(self, operator: Enum, summary: str):
         """Filter Summary based on **summary** keyword.
 
         Args:
@@ -379,7 +379,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('summary', operator, summary, TqlType.STRING)
 
-    def tag(self, operator: Enum, tag: str) -> None:
+    def tag(self, operator: Enum, tag: str):
         """Filter Tag based on **tag** keyword.
 
         Args:
@@ -388,7 +388,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('tag', operator, tag, TqlType.STRING)
 
-    def tag_owner(self, operator: Enum, tag_owner: int) -> None:
+    def tag_owner(self, operator: Enum, tag_owner: int):
         """Filter Tag Owner ID based on **tagOwner** keyword.
 
         Args:
@@ -397,7 +397,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('tagOwner', operator, tag_owner, TqlType.INTEGER)
 
-    def tag_owner_name(self, operator: Enum, tag_owner_name: str) -> None:
+    def tag_owner_name(self, operator: Enum, tag_owner_name: str):
         """Filter Tag Owner Name based on **tagOwnerName** keyword.
 
         Args:
@@ -406,7 +406,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('tagOwnerName', operator, tag_owner_name, TqlType.STRING)
 
-    def task_assignee(self, operator: Enum, task_assignee: str) -> None:
+    def task_assignee(self, operator: Enum, task_assignee: str):
         """Filter Assignee (Task) based on **taskAssignee** keyword.
 
         Args:
@@ -415,7 +415,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('taskAssignee', operator, task_assignee, TqlType.STRING)
 
-    def task_assignee_pseudo(self, operator: Enum, task_assignee_pseudo: str) -> None:
+    def task_assignee_pseudo(self, operator: Enum, task_assignee_pseudo: str):
         """Filter Assignee Pseudonym (Task) based on **taskAssigneePseudo** keyword.
 
         Args:
@@ -424,7 +424,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('taskAssigneePseudo', operator, task_assignee_pseudo, TqlType.STRING)
 
-    def task_date_added(self, operator: Enum, task_date_added: str) -> None:
+    def task_date_added(self, operator: Enum, task_date_added: str):
         """Filter Date Added (Task) based on **taskDateAdded** keyword.
 
         Args:
@@ -434,7 +434,7 @@ class GroupFilter(FilterABC):
         task_date_added = self.utils.any_to_datetime(task_date_added).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('taskDateAdded', operator, task_date_added, TqlType.STRING)
 
-    def task_due_date(self, operator: Enum, task_due_date: str) -> None:
+    def task_due_date(self, operator: Enum, task_due_date: str):
         """Filter Due Date (Task) based on **taskDueDate** keyword.
 
         Args:
@@ -444,7 +444,7 @@ class GroupFilter(FilterABC):
         task_due_date = self.utils.any_to_datetime(task_due_date).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('taskDueDate', operator, task_due_date, TqlType.STRING)
 
-    def task_escalated(self, operator: Enum, task_escalated: bool) -> None:
+    def task_escalated(self, operator: Enum, task_escalated: bool):
         """Filter Escalated (Task) based on **taskEscalated** keyword.
 
         Args:
@@ -453,7 +453,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('taskEscalated', operator, task_escalated, TqlType.BOOLEAN)
 
-    def task_escalation_date(self, operator: Enum, task_escalation_date: str) -> None:
+    def task_escalation_date(self, operator: Enum, task_escalation_date: str):
         """Filter Escalation Date (Task) based on **taskEscalationDate** keyword.
 
         Args:
@@ -465,7 +465,7 @@ class GroupFilter(FilterABC):
         )
         self._tql.add_filter('taskEscalationDate', operator, task_escalation_date, TqlType.STRING)
 
-    def task_last_modified(self, operator: Enum, task_last_modified: str) -> None:
+    def task_last_modified(self, operator: Enum, task_last_modified: str):
         """Filter Last Modified based on **taskLastModified** keyword.
 
         Args:
@@ -477,7 +477,7 @@ class GroupFilter(FilterABC):
         )
         self._tql.add_filter('taskLastModified', operator, task_last_modified, TqlType.STRING)
 
-    def task_overdue(self, operator: Enum, task_overdue: bool) -> None:
+    def task_overdue(self, operator: Enum, task_overdue: bool):
         """Filter Overdue (Task) based on **taskOverdue** keyword.
 
         Args:
@@ -486,7 +486,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('taskOverdue', operator, task_overdue, TqlType.BOOLEAN)
 
-    def task_reminded(self, operator: Enum, task_reminded: bool) -> None:
+    def task_reminded(self, operator: Enum, task_reminded: bool):
         """Filter Reminded (Task) based on **taskReminded** keyword.
 
         Args:
@@ -495,7 +495,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('taskReminded', operator, task_reminded, TqlType.BOOLEAN)
 
-    def task_reminder_date(self, operator: Enum, task_reminder_date: str) -> None:
+    def task_reminder_date(self, operator: Enum, task_reminder_date: str):
         """Filter Reminder Date (Task) based on **taskReminderDate** keyword.
 
         Args:
@@ -507,7 +507,7 @@ class GroupFilter(FilterABC):
         )
         self._tql.add_filter('taskReminderDate', operator, task_reminder_date, TqlType.STRING)
 
-    def task_status(self, operator: Enum, task_status: str) -> None:
+    def task_status(self, operator: Enum, task_status: str):
         """Filter Status (Task) based on **taskStatus** keyword.
 
         Args:
@@ -516,7 +516,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('taskStatus', operator, task_status, TqlType.STRING)
 
-    def type(self, operator: Enum, type: int) -> None:  # pylint: disable=redefined-builtin
+    def type(self, operator: Enum, type: int):  # pylint: disable=redefined-builtin
         """Filter Type based on **type** keyword.
 
         Args:
@@ -525,7 +525,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('type', operator, type, TqlType.INTEGER)
 
-    def type_name(self, operator: Enum, type_name: str) -> None:
+    def type_name(self, operator: Enum, type_name: str):
         """Filter Type Name based on **typeName** keyword.
 
         Args:
@@ -534,7 +534,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('typeName', operator, type_name, TqlType.STRING)
 
-    def upvote_count(self, operator: Enum, upvote_count: int) -> None:
+    def upvote_count(self, operator: Enum, upvote_count: int):
         """Filter Upvote Count based on **upvoteCount** keyword.
 
         Args:
@@ -543,7 +543,7 @@ class GroupFilter(FilterABC):
         """
         self._tql.add_filter('upvoteCount', operator, upvote_count, TqlType.INTEGER)
 
-    def victim_asset(self, operator: Enum, victim_asset: str) -> None:
+    def victim_asset(self, operator: Enum, victim_asset: str):
         """Filter victimAsset based on **victimAsset** keyword.
 
         Args:

--- a/tcex/api/tc/v3/indicator_attributes/indicator_attribute.py
+++ b/tcex/api/tc/v3/indicator_attributes/indicator_attribute.py
@@ -29,7 +29,7 @@ class IndicatorAttributes(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -64,7 +64,7 @@ class IndicatorAttribute(ObjectABC):
         value (str, kwargs): Attribute value.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -85,7 +85,7 @@ class IndicatorAttribute(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['IndicatorAttributeModel', dict]) -> None:
+    def model(self, data: Union['IndicatorAttributeModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/indicator_attributes/indicator_attribute_filter.py
+++ b/tcex/api/tc/v3/indicator_attributes/indicator_attribute_filter.py
@@ -18,7 +18,7 @@ class IndicatorAttributeFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.INDICATOR_ATTRIBUTES.value
 
-    def date_added(self, operator: Enum, date_added: str) -> None:
+    def date_added(self, operator: Enum, date_added: str):
         """Filter Date Added based on **dateAdded** keyword.
 
         Args:
@@ -28,7 +28,7 @@ class IndicatorAttributeFilter(FilterABC):
         date_added = self.utils.any_to_datetime(date_added).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateAdded', operator, date_added, TqlType.STRING)
 
-    def date_val(self, operator: Enum, date_val: str) -> None:
+    def date_val(self, operator: Enum, date_val: str):
         """Filter Date based on **dateVal** keyword.
 
         Args:
@@ -38,7 +38,7 @@ class IndicatorAttributeFilter(FilterABC):
         date_val = self.utils.any_to_datetime(date_val).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateVal', operator, date_val, TqlType.STRING)
 
-    def displayed(self, operator: Enum, displayed: bool) -> None:
+    def displayed(self, operator: Enum, displayed: bool):
         """Filter Displayed based on **displayed** keyword.
 
         Args:
@@ -67,7 +67,7 @@ class IndicatorAttributeFilter(FilterABC):
         self._tql.add_filter('hasSecurityLabel', TqlOperator.EQ, security_labels, TqlType.SUB_QUERY)
         return security_labels
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -76,7 +76,7 @@ class IndicatorAttributeFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def indicator_id(self, operator: Enum, indicator_id: int) -> None:
+    def indicator_id(self, operator: Enum, indicator_id: int):
         """Filter Indicator ID based on **indicatorId** keyword.
 
         Args:
@@ -85,7 +85,7 @@ class IndicatorAttributeFilter(FilterABC):
         """
         self._tql.add_filter('indicatorId', operator, indicator_id, TqlType.INTEGER)
 
-    def int_val(self, operator: Enum, int_val: int) -> None:
+    def int_val(self, operator: Enum, int_val: int):
         """Filter Integer Value based on **intVal** keyword.
 
         Args:
@@ -94,7 +94,7 @@ class IndicatorAttributeFilter(FilterABC):
         """
         self._tql.add_filter('intVal', operator, int_val, TqlType.INTEGER)
 
-    def last_modified(self, operator: Enum, last_modified: str) -> None:
+    def last_modified(self, operator: Enum, last_modified: str):
         """Filter Last Modified based on **lastModified** keyword.
 
         Args:
@@ -104,7 +104,7 @@ class IndicatorAttributeFilter(FilterABC):
         last_modified = self.utils.any_to_datetime(last_modified).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('lastModified', operator, last_modified, TqlType.STRING)
 
-    def max_size(self, operator: Enum, max_size: int) -> None:
+    def max_size(self, operator: Enum, max_size: int):
         """Filter Max Size based on **maxSize** keyword.
 
         Args:
@@ -113,7 +113,7 @@ class IndicatorAttributeFilter(FilterABC):
         """
         self._tql.add_filter('maxSize', operator, max_size, TqlType.INTEGER)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -122,7 +122,7 @@ class IndicatorAttributeFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -131,7 +131,7 @@ class IndicatorAttributeFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def source(self, operator: Enum, source: str) -> None:
+    def source(self, operator: Enum, source: str):
         """Filter Source based on **source** keyword.
 
         Args:
@@ -140,7 +140,7 @@ class IndicatorAttributeFilter(FilterABC):
         """
         self._tql.add_filter('source', operator, source, TqlType.STRING)
 
-    def text(self, operator: Enum, text: str) -> None:
+    def text(self, operator: Enum, text: str):
         """Filter Text based on **text** keyword.
 
         Args:
@@ -149,7 +149,7 @@ class IndicatorAttributeFilter(FilterABC):
         """
         self._tql.add_filter('text', operator, text, TqlType.STRING)
 
-    def type(self, operator: Enum, type: int) -> None:  # pylint: disable=redefined-builtin
+    def type(self, operator: Enum, type: int):  # pylint: disable=redefined-builtin
         """Filter Type ID based on **type** keyword.
 
         Args:
@@ -158,7 +158,7 @@ class IndicatorAttributeFilter(FilterABC):
         """
         self._tql.add_filter('type', operator, type, TqlType.INTEGER)
 
-    def type_name(self, operator: Enum, type_name: str) -> None:
+    def type_name(self, operator: Enum, type_name: str):
         """Filter Type Name based on **typeName** keyword.
 
         Args:
@@ -167,7 +167,7 @@ class IndicatorAttributeFilter(FilterABC):
         """
         self._tql.add_filter('typeName', operator, type_name, TqlType.STRING)
 
-    def user(self, operator: Enum, user: str) -> None:
+    def user(self, operator: Enum, user: str):
         """Filter User based on **user** keyword.
 
         Args:

--- a/tcex/api/tc/v3/indicators/indicator.py
+++ b/tcex/api/tc/v3/indicators/indicator.py
@@ -43,7 +43,7 @@ class Indicators(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -70,7 +70,7 @@ class Indicators(ObjectCollectionABC):
         deleted_since: Optional[Union[datetime, str]],
         type_: Optional[str] = None,
         owner: Optional[str] = None,
-    ) -> None:
+    ):
         """Return deleted indicators.
 
         This will not use the default params set on the "Indicators"
@@ -130,7 +130,7 @@ class Indicator(ObjectABC):
         whois_active (bool, kwargs): Is whois active for the indicator?
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -151,7 +151,7 @@ class Indicator(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['IndicatorModel', dict]) -> None:
+    def model(self, data: Union['IndicatorModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change
@@ -169,7 +169,7 @@ class Indicator(ObjectABC):
 
         return {'type': type_, 'id': self.model.id, 'value': self.model.summary}
 
-    def remove(self, params: Optional[dict] = None) -> None:
+    def remove(self, params: Optional[dict] = None):
         """Remove a nested object."""
         method = 'PUT'
         unique_id = self._calculate_unique_id()
@@ -261,7 +261,7 @@ class Indicator(ObjectABC):
 
         yield from self._iterate_over_sublist(Tags)
 
-    def stage_associated_case(self, data: Union[dict, 'ObjectABC', 'CaseModel']) -> None:
+    def stage_associated_case(self, data: Union[dict, 'ObjectABC', 'CaseModel']):
         """Stage case on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -273,7 +273,7 @@ class Indicator(ObjectABC):
         data._staged = True
         self.model.associated_cases.data.append(data)
 
-    def stage_associated_artifact(self, data: Union[dict, 'ObjectABC', 'ArtifactModel']) -> None:
+    def stage_associated_artifact(self, data: Union[dict, 'ObjectABC', 'ArtifactModel']):
         """Stage artifact on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -285,7 +285,7 @@ class Indicator(ObjectABC):
         data._staged = True
         self.model.associated_artifacts.data.append(data)
 
-    def stage_associated_group(self, data: Union[dict, 'ObjectABC', 'GroupModel']) -> None:
+    def stage_associated_group(self, data: Union[dict, 'ObjectABC', 'GroupModel']):
         """Stage group on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -297,7 +297,7 @@ class Indicator(ObjectABC):
         data._staged = True
         self.model.associated_groups.data.append(data)
 
-    def stage_attribute(self, data: Union[dict, 'ObjectABC', 'IndicatorAttributeModel']) -> None:
+    def stage_attribute(self, data: Union[dict, 'ObjectABC', 'IndicatorAttributeModel']):
         """Stage attribute on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -309,7 +309,7 @@ class Indicator(ObjectABC):
         data._staged = True
         self.model.attributes.data.append(data)
 
-    def stage_security_label(self, data: Union[dict, 'ObjectABC', 'SecurityLabelModel']) -> None:
+    def stage_security_label(self, data: Union[dict, 'ObjectABC', 'SecurityLabelModel']):
         """Stage security_label on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -321,7 +321,7 @@ class Indicator(ObjectABC):
         data._staged = True
         self.model.security_labels.data.append(data)
 
-    def stage_tag(self, data: Union[dict, 'ObjectABC', 'TagModel']) -> None:
+    def stage_tag(self, data: Union[dict, 'ObjectABC', 'TagModel']):
         """Stage tag on the object."""
         if isinstance(data, ObjectABC):
             data = data.model

--- a/tcex/api/tc/v3/indicators/indicator_filter.py
+++ b/tcex/api/tc/v3/indicators/indicator_filter.py
@@ -18,7 +18,7 @@ class IndicatorFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.INDICATORS.value
 
-    def active_locked(self, operator: Enum, active_locked: bool) -> None:
+    def active_locked(self, operator: Enum, active_locked: bool):
         """Filter Indicator Status Locked based on **activeLocked** keyword.
 
         Args:
@@ -27,7 +27,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('activeLocked', operator, active_locked, TqlType.BOOLEAN)
 
-    def address_asn(self, operator: Enum, address_asn: int) -> None:
+    def address_asn(self, operator: Enum, address_asn: int):
         """Filter ASN (Address) based on **addressAsn** keyword.
 
         Args:
@@ -36,7 +36,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('addressAsn', operator, address_asn, TqlType.INTEGER)
 
-    def address_cidr(self, operator: Enum, address_cidr: str) -> None:
+    def address_cidr(self, operator: Enum, address_cidr: str):
         """Filter CIDR (Address) based on **addressCidr** keyword.
 
         Args:
@@ -45,7 +45,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('addressCidr', operator, address_cidr, TqlType.STRING)
 
-    def address_city(self, operator: Enum, address_city: str) -> None:
+    def address_city(self, operator: Enum, address_city: str):
         """Filter City (Address) based on **addressCity** keyword.
 
         Args:
@@ -54,7 +54,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('addressCity', operator, address_city, TqlType.STRING)
 
-    def address_country_code(self, operator: Enum, address_country_code: str) -> None:
+    def address_country_code(self, operator: Enum, address_country_code: str):
         """Filter Country Code (Address) based on **addressCountryCode** keyword.
 
         Args:
@@ -63,7 +63,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('addressCountryCode', operator, address_country_code, TqlType.STRING)
 
-    def address_country_name(self, operator: Enum, address_country_name: str) -> None:
+    def address_country_name(self, operator: Enum, address_country_name: str):
         """Filter Country Name (Address) based on **addressCountryName** keyword.
 
         Args:
@@ -72,7 +72,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('addressCountryName', operator, address_country_name, TqlType.STRING)
 
-    def address_ip_val(self, operator: Enum, address_ip_val: int) -> None:
+    def address_ip_val(self, operator: Enum, address_ip_val: int):
         """Filter Value (Address) based on **addressIpVal** keyword.
 
         Args:
@@ -81,7 +81,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('addressIpVal', operator, address_ip_val, TqlType.INTEGER)
 
-    def address_is_ipv6(self, operator: Enum, address_is_ipv6: bool) -> None:
+    def address_is_ipv6(self, operator: Enum, address_is_ipv6: bool):
         """Filter Type (Address) based on **addressIsIpv6** keyword.
 
         Args:
@@ -90,7 +90,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('addressIsIpv6', operator, address_is_ipv6, TqlType.BOOLEAN)
 
-    def address_registering_org(self, operator: Enum, address_registering_org: str) -> None:
+    def address_registering_org(self, operator: Enum, address_registering_org: str):
         """Filter Registering Org (Address) based on **addressRegisteringOrg** keyword.
 
         Args:
@@ -101,7 +101,7 @@ class IndicatorFilter(FilterABC):
             'addressRegisteringOrg', operator, address_registering_org, TqlType.STRING
         )
 
-    def address_state(self, operator: Enum, address_state: str) -> None:
+    def address_state(self, operator: Enum, address_state: str):
         """Filter State (Address) based on **addressState** keyword.
 
         Args:
@@ -110,7 +110,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('addressState', operator, address_state, TqlType.STRING)
 
-    def address_timezone(self, operator: Enum, address_timezone: str) -> None:
+    def address_timezone(self, operator: Enum, address_timezone: str):
         """Filter Time Zone (Address) based on **addressTimezone** keyword.
 
         Args:
@@ -119,7 +119,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('addressTimezone', operator, address_timezone, TqlType.STRING)
 
-    def associated_group(self, operator: Enum, associated_group: int) -> None:
+    def associated_group(self, operator: Enum, associated_group: int):
         """Filter associatedGroup based on **associatedGroup** keyword.
 
         Args:
@@ -128,7 +128,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('associatedGroup', operator, associated_group, TqlType.INTEGER)
 
-    def attribute(self, operator: Enum, attribute: str) -> None:
+    def attribute(self, operator: Enum, attribute: str):
         """Filter attribute based on **attribute** keyword.
 
         Args:
@@ -137,7 +137,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('attribute', operator, attribute, TqlType.STRING)
 
-    def confidence(self, operator: Enum, confidence: int) -> None:
+    def confidence(self, operator: Enum, confidence: int):
         """Filter Confidence Rating based on **confidence** keyword.
 
         Args:
@@ -146,7 +146,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('confidence', operator, confidence, TqlType.INTEGER)
 
-    def date_added(self, operator: Enum, date_added: str) -> None:
+    def date_added(self, operator: Enum, date_added: str):
         """Filter Date Added based on **dateAdded** keyword.
 
         Args:
@@ -156,7 +156,7 @@ class IndicatorFilter(FilterABC):
         date_added = self.utils.any_to_datetime(date_added).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateAdded', operator, date_added, TqlType.STRING)
 
-    def description(self, operator: Enum, description: str) -> None:
+    def description(self, operator: Enum, description: str):
         """Filter Description based on **description** keyword.
 
         Args:
@@ -165,7 +165,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('description', operator, description, TqlType.STRING)
 
-    def false_positive_count(self, operator: Enum, false_positive_count: int) -> None:
+    def false_positive_count(self, operator: Enum, false_positive_count: int):
         """Filter False Positive Count based on **falsePositiveCount** keyword.
 
         Args:
@@ -175,7 +175,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('falsePositiveCount', operator, false_positive_count, TqlType.INTEGER)
 
-    def file_size(self, operator: Enum, file_size: int) -> None:
+    def file_size(self, operator: Enum, file_size: int):
         """Filter Size (File) based on **fileSize** keyword.
 
         Args:
@@ -273,7 +273,7 @@ class IndicatorFilter(FilterABC):
         self._tql.add_filter('hasVictimAsset', TqlOperator.EQ, victim_assets, TqlType.SUB_QUERY)
         return victim_assets
 
-    def host_dns_active(self, operator: Enum, host_dns_active: bool) -> None:
+    def host_dns_active(self, operator: Enum, host_dns_active: bool):
         """Filter DNS Active (Host) based on **hostDnsActive** keyword.
 
         Args:
@@ -282,7 +282,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('hostDnsActive', operator, host_dns_active, TqlType.BOOLEAN)
 
-    def host_whois_active(self, operator: Enum, host_whois_active: bool) -> None:
+    def host_whois_active(self, operator: Enum, host_whois_active: bool):
         """Filter Whois Active (Host) based on **hostWhoisActive** keyword.
 
         Args:
@@ -291,7 +291,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('hostWhoisActive', operator, host_whois_active, TqlType.BOOLEAN)
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -300,7 +300,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def indicator_active(self, operator: Enum, indicator_active: bool) -> None:
+    def indicator_active(self, operator: Enum, indicator_active: bool):
         """Filter Indicator Status based on **indicatorActive** keyword.
 
         Args:
@@ -309,7 +309,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('indicatorActive', operator, indicator_active, TqlType.BOOLEAN)
 
-    def last_false_positive(self, operator: Enum, last_false_positive: str) -> None:
+    def last_false_positive(self, operator: Enum, last_false_positive: str):
         """Filter False Positive Last Observed based on **lastFalsePositive** keyword.
 
         Args:
@@ -321,7 +321,7 @@ class IndicatorFilter(FilterABC):
         )
         self._tql.add_filter('lastFalsePositive', operator, last_false_positive, TqlType.STRING)
 
-    def last_modified(self, operator: Enum, last_modified: str) -> None:
+    def last_modified(self, operator: Enum, last_modified: str):
         """Filter Last Modified based on **lastModified** keyword.
 
         Args:
@@ -331,7 +331,7 @@ class IndicatorFilter(FilterABC):
         last_modified = self.utils.any_to_datetime(last_modified).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('lastModified', operator, last_modified, TqlType.STRING)
 
-    def last_observed(self, operator: Enum, last_observed: str) -> None:
+    def last_observed(self, operator: Enum, last_observed: str):
         """Filter Last Observed based on **lastObserved** keyword.
 
         Args:
@@ -341,7 +341,7 @@ class IndicatorFilter(FilterABC):
         last_observed = self.utils.any_to_datetime(last_observed).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('lastObserved', operator, last_observed, TqlType.STRING)
 
-    def observation_count(self, operator: Enum, observation_count: int) -> None:
+    def observation_count(self, operator: Enum, observation_count: int):
         """Filter Observation Count based on **observationCount** keyword.
 
         Args:
@@ -350,7 +350,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('observationCount', operator, observation_count, TqlType.INTEGER)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -359,7 +359,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -368,7 +368,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def rating(self, operator: Enum, rating: int) -> None:
+    def rating(self, operator: Enum, rating: int):
         """Filter Threat Rating based on **rating** keyword.
 
         Args:
@@ -377,7 +377,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('rating', operator, rating, TqlType.INTEGER)
 
-    def security_label(self, operator: Enum, security_label: str) -> None:
+    def security_label(self, operator: Enum, security_label: str):
         """Filter Security Label based on **securityLabel** keyword.
 
         Args:
@@ -386,7 +386,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('securityLabel', operator, security_label, TqlType.STRING)
 
-    def source(self, operator: Enum, source: str) -> None:
+    def source(self, operator: Enum, source: str):
         """Filter Source based on **source** keyword.
 
         Args:
@@ -395,7 +395,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('source', operator, source, TqlType.STRING)
 
-    def summary(self, operator: Enum, summary: str) -> None:
+    def summary(self, operator: Enum, summary: str):
         """Filter Summary based on **summary** keyword.
 
         Args:
@@ -404,7 +404,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('summary', operator, summary, TqlType.STRING)
 
-    def tag(self, operator: Enum, tag: str) -> None:
+    def tag(self, operator: Enum, tag: str):
         """Filter Tag based on **tag** keyword.
 
         Args:
@@ -413,7 +413,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('tag', operator, tag, TqlType.STRING)
 
-    def tag_owner(self, operator: Enum, tag_owner: int) -> None:
+    def tag_owner(self, operator: Enum, tag_owner: int):
         """Filter Tag Owner ID based on **tagOwner** keyword.
 
         Args:
@@ -422,7 +422,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('tagOwner', operator, tag_owner, TqlType.INTEGER)
 
-    def tag_owner_name(self, operator: Enum, tag_owner_name: str) -> None:
+    def tag_owner_name(self, operator: Enum, tag_owner_name: str):
         """Filter Tag Owner Name based on **tagOwnerName** keyword.
 
         Args:
@@ -431,7 +431,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('tagOwnerName', operator, tag_owner_name, TqlType.STRING)
 
-    def threat_assess_score(self, operator: Enum, threat_assess_score: int) -> None:
+    def threat_assess_score(self, operator: Enum, threat_assess_score: int):
         """Filter ThreatAssess Score based on **threatAssessScore** keyword.
 
         Args:
@@ -440,7 +440,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('threatAssessScore', operator, threat_assess_score, TqlType.INTEGER)
 
-    def type(self, operator: Enum, type: int) -> None:  # pylint: disable=redefined-builtin
+    def type(self, operator: Enum, type: int):  # pylint: disable=redefined-builtin
         """Filter Type ID based on **type** keyword.
 
         Args:
@@ -449,7 +449,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('type', operator, type, TqlType.INTEGER)
 
-    def type_name(self, operator: Enum, type_name: str) -> None:
+    def type_name(self, operator: Enum, type_name: str):
         """Filter Type Name based on **typeName** keyword.
 
         Args:
@@ -458,7 +458,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('typeName', operator, type_name, TqlType.STRING)
 
-    def value1(self, operator: Enum, value1: str) -> None:
+    def value1(self, operator: Enum, value1: str):
         """Filter value1 based on **value1** keyword.
 
         Args:
@@ -467,7 +467,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('value1', operator, value1, TqlType.STRING)
 
-    def value2(self, operator: Enum, value2: str) -> None:
+    def value2(self, operator: Enum, value2: str):
         """Filter value2 based on **value2** keyword.
 
         Args:
@@ -476,7 +476,7 @@ class IndicatorFilter(FilterABC):
         """
         self._tql.add_filter('value2', operator, value2, TqlType.STRING)
 
-    def value3(self, operator: Enum, value3: str) -> None:
+    def value3(self, operator: Enum, value3: str):
         """Filter value3 based on **value3** keyword.
 
         Args:

--- a/tcex/api/tc/v3/notes/note.py
+++ b/tcex/api/tc/v3/notes/note.py
@@ -26,7 +26,7 @@ class Notes(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -62,7 +62,7 @@ class Note(ObjectABC):
         workflow_event_id (int, kwargs): The ID of the Event on which to apply the Note.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -83,7 +83,7 @@ class Note(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['NoteModel', dict]) -> None:
+    def model(self, data: Union['NoteModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/notes/note_filter.py
+++ b/tcex/api/tc/v3/notes/note_filter.py
@@ -18,7 +18,7 @@ class NoteFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.NOTES.value
 
-    def artifact_id(self, operator: Enum, artifact_id: int) -> None:
+    def artifact_id(self, operator: Enum, artifact_id: int):
         """Filter Artifact ID based on **artifactId** keyword.
 
         Args:
@@ -27,7 +27,7 @@ class NoteFilter(FilterABC):
         """
         self._tql.add_filter('artifactId', operator, artifact_id, TqlType.INTEGER)
 
-    def author(self, operator: Enum, author: str) -> None:
+    def author(self, operator: Enum, author: str):
         """Filter Author based on **author** keyword.
 
         Args:
@@ -36,7 +36,7 @@ class NoteFilter(FilterABC):
         """
         self._tql.add_filter('author', operator, author, TqlType.STRING)
 
-    def case_id(self, operator: Enum, case_id: int) -> None:
+    def case_id(self, operator: Enum, case_id: int):
         """Filter Case ID based on **caseId** keyword.
 
         Args:
@@ -45,7 +45,7 @@ class NoteFilter(FilterABC):
         """
         self._tql.add_filter('caseId', operator, case_id, TqlType.INTEGER)
 
-    def date_added(self, operator: Enum, date_added: str) -> None:
+    def date_added(self, operator: Enum, date_added: str):
         """Filter Date Added based on **dateAdded** keyword.
 
         Args:
@@ -85,7 +85,7 @@ class NoteFilter(FilterABC):
         self._tql.add_filter('hasTask', TqlOperator.EQ, tasks, TqlType.SUB_QUERY)
         return tasks
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -94,7 +94,7 @@ class NoteFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def last_modified(self, operator: Enum, last_modified: str) -> None:
+    def last_modified(self, operator: Enum, last_modified: str):
         """Filter Last Modified based on **lastModified** keyword.
 
         Args:
@@ -104,7 +104,7 @@ class NoteFilter(FilterABC):
         last_modified = self.utils.any_to_datetime(last_modified).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('lastModified', operator, last_modified, TqlType.STRING)
 
-    def summary(self, operator: Enum, summary: str) -> None:
+    def summary(self, operator: Enum, summary: str):
         """Filter Summary based on **summary** keyword.
 
         Args:
@@ -113,7 +113,7 @@ class NoteFilter(FilterABC):
         """
         self._tql.add_filter('summary', operator, summary, TqlType.STRING)
 
-    def task_id(self, operator: Enum, task_id: int) -> None:
+    def task_id(self, operator: Enum, task_id: int):
         """Filter Task ID based on **taskId** keyword.
 
         Args:
@@ -122,7 +122,7 @@ class NoteFilter(FilterABC):
         """
         self._tql.add_filter('taskId', operator, task_id, TqlType.INTEGER)
 
-    def workflow_event_id(self, operator: Enum, workflow_event_id: int) -> None:
+    def workflow_event_id(self, operator: Enum, workflow_event_id: int):
         """Filter Workflow Event ID based on **workflowEventId** keyword.
 
         Args:

--- a/tcex/api/tc/v3/object_abc.py
+++ b/tcex/api/tc/v3/object_abc.py
@@ -34,7 +34,7 @@ class ObjectABC(ABC):
     methods are used.
     """
 
-    def __init__(self, session) -> None:
+    def __init__(self, session):
         """Initialize class properties."""
         self._session = session
 
@@ -102,7 +102,7 @@ class ObjectABC(ABC):
         body: Optional[Union[bytes, str]] = None,
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
-    ) -> Response:
+    ) -> 'Response':
         """Handle standard request with error checking."""
         try:
             self.request = self._session.request(
@@ -138,7 +138,7 @@ class ObjectABC(ABC):
             self.log_response_text(self.request)
 
     @staticmethod
-    def _validate_id(id_: int, url: str) -> None:
+    def _validate_id(id_: int, url: str):
         """Raise exception is id is not provided."""
         if not id_:  # pragma: no cover
             message = '{"message": "No ID provided.", "status": "Error"}'
@@ -154,7 +154,7 @@ class ObjectABC(ABC):
         """Return the available query param field names for this object."""
         return [fd.get('name') for fd in self.fields]
 
-    def create(self, params: Optional[dict] = None) -> Response:
+    def create(self, params: Optional[dict] = None) -> 'Response':
         """Create or Update the Case Management object.
 
         This is determined based on if the id is already present in the object.
@@ -177,7 +177,7 @@ class ObjectABC(ABC):
 
         return self.request
 
-    def delete(self, params: Optional[dict] = None) -> None:
+    def delete(self, params: Optional[dict] = None):
         """Delete the object."""
         method = 'DELETE'
         body = self.model.gen_body_json(method)
@@ -258,7 +258,7 @@ class ObjectABC(ABC):
 
         return self.request
 
-    def log_response_text(self, response: Response) -> None:
+    def log_response_text(self, response: Response):
         """Log the response text."""
         response_text = 'response text: (text to large to log)'
         if len(response.content) < 5000:  # check size of content for performance
@@ -271,7 +271,7 @@ class ObjectABC(ABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['V3Type', dict]) -> None:
+    def model(self, data: Union['V3Type', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change
@@ -330,7 +330,7 @@ class ObjectABC(ABC):
             status = False
         return status
 
-    def update(self, mode: Optional[str] = None, params: Optional[dict] = None) -> Response:
+    def update(self, mode: Optional[str] = None, params: Optional[dict] = None) -> 'Response':
         """Create or Update the Case Management object.
 
         This is determined based on if the id is already present in the object.

--- a/tcex/api/tc/v3/object_collection_abc.py
+++ b/tcex/api/tc/v3/object_collection_abc.py
@@ -54,7 +54,7 @@ class ObjectCollectionABC(ABC):
         session,
         tql_filters: Optional[list] = None,  # This will be removed!
         params: Optional[dict] = None,
-    ) -> None:
+    ):
         """Initialize class properties."""
         self._params = params or {}
         self._tql_filters = tql_filters or []
@@ -96,7 +96,7 @@ class ObjectCollectionABC(ABC):
         return self.request.json().get('count', len(self.request.json().get('data', [])))
 
     @property
-    def _api_endpoint(self) -> None:  # pragma: no cover
+    def _api_endpoint(self):  # pragma: no cover
         """Return filter method."""
         raise NotImplementedError('Child class must implement this method.')
 
@@ -107,7 +107,7 @@ class ObjectCollectionABC(ABC):
         body: Optional[Union[bytes, str]] = None,
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
-    ) -> None:
+    ):
         """Handle standard request with error checking."""
         try:
             self.request = self._session.request(
@@ -141,11 +141,11 @@ class ObjectCollectionABC(ABC):
         self.log_response_text(self.request)
 
     @property
-    def filter(self) -> None:  # pragma: no cover
+    def filter(self):  # pragma: no cover
         """Return filter method."""
         raise NotImplementedError('Child class must implement this method.')
 
-    def log_response_text(self, response: Response) -> None:
+    def log_response_text(self, response: Response):
         """Log the response text."""
         response_text = 'response text: (text to large to log)'
         if len(response.content) < 5000:  # check size of content for performance
@@ -223,7 +223,7 @@ class ObjectCollectionABC(ABC):
         return self._params
 
     @params.setter
-    def params(self, params: dict) -> None:
+    def params(self, params: dict):
         """Set the parameters of the case management object collection."""
         self._params = params
 
@@ -254,7 +254,7 @@ class ObjectCollectionABC(ABC):
         return self._timeout
 
     @timeout.setter
-    def timeout(self, timeout: int) -> None:
+    def timeout(self, timeout: int):
         """Set the timeout of the case management object collection."""
         self._timeout = timeout
 

--- a/tcex/api/tc/v3/security/owner_roles/owner_role.py
+++ b/tcex/api/tc/v3/security/owner_roles/owner_role.py
@@ -26,7 +26,7 @@ class OwnerRoles(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -52,7 +52,7 @@ class OwnerRoles(ObjectCollectionABC):
 class OwnerRole(ObjectABC):
     """OwnerRoles Object."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -73,7 +73,7 @@ class OwnerRole(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['OwnerRoleModel', dict]) -> None:
+    def model(self, data: Union['OwnerRoleModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/security/owner_roles/owner_role_filter.py
+++ b/tcex/api/tc/v3/security/owner_roles/owner_role_filter.py
@@ -16,7 +16,7 @@ class OwnerRoleFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.OWNER_ROLES.value
 
-    def available(self, operator: Enum, available: bool) -> None:
+    def available(self, operator: Enum, available: bool):
         """Filter Available based on **available** keyword.
 
         Args:
@@ -25,7 +25,7 @@ class OwnerRoleFilter(FilterABC):
         """
         self._tql.add_filter('available', operator, available, TqlType.BOOLEAN)
 
-    def comm_role(self, operator: Enum, comm_role: bool) -> None:
+    def comm_role(self, operator: Enum, comm_role: bool):
         """Filter Community Role based on **commRole** keyword.
 
         Args:
@@ -34,7 +34,7 @@ class OwnerRoleFilter(FilterABC):
         """
         self._tql.add_filter('commRole', operator, comm_role, TqlType.BOOLEAN)
 
-    def description_admin(self, operator: Enum, description_admin: str) -> None:
+    def description_admin(self, operator: Enum, description_admin: str):
         """Filter Admin Description based on **descriptionAdmin** keyword.
 
         Args:
@@ -43,7 +43,7 @@ class OwnerRoleFilter(FilterABC):
         """
         self._tql.add_filter('descriptionAdmin', operator, description_admin, TqlType.STRING)
 
-    def description_comm(self, operator: Enum, description_comm: str) -> None:
+    def description_comm(self, operator: Enum, description_comm: str):
         """Filter Community Description based on **descriptionComm** keyword.
 
         Args:
@@ -52,7 +52,7 @@ class OwnerRoleFilter(FilterABC):
         """
         self._tql.add_filter('descriptionComm', operator, description_comm, TqlType.STRING)
 
-    def description_org(self, operator: Enum, description_org: str) -> None:
+    def description_org(self, operator: Enum, description_org: str):
         """Filter Organization Description based on **descriptionOrg** keyword.
 
         Args:
@@ -61,7 +61,7 @@ class OwnerRoleFilter(FilterABC):
         """
         self._tql.add_filter('descriptionOrg', operator, description_org, TqlType.STRING)
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -70,7 +70,7 @@ class OwnerRoleFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def name(self, operator: Enum, name: str) -> None:
+    def name(self, operator: Enum, name: str):
         """Filter Name based on **name** keyword.
 
         Args:
@@ -79,7 +79,7 @@ class OwnerRoleFilter(FilterABC):
         """
         self._tql.add_filter('name', operator, name, TqlType.STRING)
 
-    def org_role(self, operator: Enum, org_role: bool) -> None:
+    def org_role(self, operator: Enum, org_role: bool):
         """Filter Organization Role based on **orgRole** keyword.
 
         Args:
@@ -88,7 +88,7 @@ class OwnerRoleFilter(FilterABC):
         """
         self._tql.add_filter('orgRole', operator, org_role, TqlType.BOOLEAN)
 
-    def version(self, operator: Enum, version: int) -> None:
+    def version(self, operator: Enum, version: int):
         """Filter Version based on **version** keyword.
 
         Args:

--- a/tcex/api/tc/v3/security/owners/owner.py
+++ b/tcex/api/tc/v3/security/owners/owner.py
@@ -26,7 +26,7 @@ class Owners(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -52,7 +52,7 @@ class Owners(ObjectCollectionABC):
 class Owner(ObjectABC):
     """Owners Object."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -73,7 +73,7 @@ class Owner(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['OwnerModel', dict]) -> None:
+    def model(self, data: Union['OwnerModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/security/owners/owner_filter.py
+++ b/tcex/api/tc/v3/security/owners/owner_filter.py
@@ -16,7 +16,7 @@ class OwnerFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.OWNERS.value
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -25,7 +25,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def owner_id(self, operator: Enum, owner_id: int) -> None:
+    def owner_id(self, operator: Enum, owner_id: int):
         """Filter Owner ID based on **ownerId** keyword.
 
         Args:
@@ -34,7 +34,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('ownerId', operator, owner_id, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -43,7 +43,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def perm_apps(self, operator: Enum, perm_apps: str) -> None:
+    def perm_apps(self, operator: Enum, perm_apps: str):
         """Filter Apps Permission based on **permApps** keyword.
 
         Args:
@@ -52,7 +52,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permApps', operator, perm_apps, TqlType.STRING)
 
-    def perm_artifact(self, operator: Enum, perm_artifact: str) -> None:
+    def perm_artifact(self, operator: Enum, perm_artifact: str):
         """Filter Artifact Permission based on **permArtifact** keyword.
 
         Args:
@@ -61,7 +61,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permArtifact', operator, perm_artifact, TqlType.STRING)
 
-    def perm_attribute(self, operator: Enum, perm_attribute: str) -> None:
+    def perm_attribute(self, operator: Enum, perm_attribute: str):
         """Filter Attribute Permission based on **permAttribute** keyword.
 
         Args:
@@ -70,7 +70,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permAttribute', operator, perm_attribute, TqlType.STRING)
 
-    def perm_attribute_type(self, operator: Enum, perm_attribute_type: str) -> None:
+    def perm_attribute_type(self, operator: Enum, perm_attribute_type: str):
         """Filter AttributeType Permission based on **permAttributeType** keyword.
 
         Args:
@@ -79,7 +79,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permAttributeType', operator, perm_attribute_type, TqlType.STRING)
 
-    def perm_case_tag(self, operator: Enum, perm_case_tag: str) -> None:
+    def perm_case_tag(self, operator: Enum, perm_case_tag: str):
         """Filter CaseTag Permission based on **permCaseTag** keyword.
 
         Args:
@@ -88,7 +88,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permCaseTag', operator, perm_case_tag, TqlType.STRING)
 
-    def perm_comment(self, operator: Enum, perm_comment: str) -> None:
+    def perm_comment(self, operator: Enum, perm_comment: str):
         """Filter Comment Permission based on **permComment** keyword.
 
         Args:
@@ -97,7 +97,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permComment', operator, perm_comment, TqlType.STRING)
 
-    def perm_copy_data(self, operator: Enum, perm_copy_data: str) -> None:
+    def perm_copy_data(self, operator: Enum, perm_copy_data: str):
         """Filter CopyData Permission based on **permCopyData** keyword.
 
         Args:
@@ -106,7 +106,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permCopyData', operator, perm_copy_data, TqlType.STRING)
 
-    def perm_group(self, operator: Enum, perm_group: str) -> None:
+    def perm_group(self, operator: Enum, perm_group: str):
         """Filter Group Permission based on **permGroup** keyword.
 
         Args:
@@ -115,7 +115,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permGroup', operator, perm_group, TqlType.STRING)
 
-    def perm_indicator(self, operator: Enum, perm_indicator: str) -> None:
+    def perm_indicator(self, operator: Enum, perm_indicator: str):
         """Filter Indicator Permission based on **permIndicator** keyword.
 
         Args:
@@ -124,7 +124,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permIndicator', operator, perm_indicator, TqlType.STRING)
 
-    def perm_invite(self, operator: Enum, perm_invite: str) -> None:
+    def perm_invite(self, operator: Enum, perm_invite: str):
         """Filter Invite Permission based on **permInvite** keyword.
 
         Args:
@@ -133,7 +133,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permInvite', operator, perm_invite, TqlType.STRING)
 
-    def perm_members(self, operator: Enum, perm_members: str) -> None:
+    def perm_members(self, operator: Enum, perm_members: str):
         """Filter Members Permission based on **permMembers** keyword.
 
         Args:
@@ -142,7 +142,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permMembers', operator, perm_members, TqlType.STRING)
 
-    def perm_playbooks(self, operator: Enum, perm_playbooks: str) -> None:
+    def perm_playbooks(self, operator: Enum, perm_playbooks: str):
         """Filter Playbooks Permission based on **permPlaybooks** keyword.
 
         Args:
@@ -151,7 +151,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permPlaybooks', operator, perm_playbooks, TqlType.STRING)
 
-    def perm_playbooks_execute(self, operator: Enum, perm_playbooks_execute: str) -> None:
+    def perm_playbooks_execute(self, operator: Enum, perm_playbooks_execute: str):
         """Filter PlaybooksExecute Permission based on **permPlaybooksExecute** keyword.
 
         Args:
@@ -162,7 +162,7 @@ class OwnerFilter(FilterABC):
             'permPlaybooksExecute', operator, perm_playbooks_execute, TqlType.STRING
         )
 
-    def perm_post(self, operator: Enum, perm_post: str) -> None:
+    def perm_post(self, operator: Enum, perm_post: str):
         """Filter Post Permission based on **permPost** keyword.
 
         Args:
@@ -171,7 +171,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permPost', operator, perm_post, TqlType.STRING)
 
-    def perm_publish(self, operator: Enum, perm_publish: str) -> None:
+    def perm_publish(self, operator: Enum, perm_publish: str):
         """Filter Publish Permission based on **permPublish** keyword.
 
         Args:
@@ -180,7 +180,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permPublish', operator, perm_publish, TqlType.STRING)
 
-    def perm_security_label(self, operator: Enum, perm_security_label: str) -> None:
+    def perm_security_label(self, operator: Enum, perm_security_label: str):
         """Filter SecurityLabel Permission based on **permSecurityLabel** keyword.
 
         Args:
@@ -189,7 +189,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permSecurityLabel', operator, perm_security_label, TqlType.STRING)
 
-    def perm_settings(self, operator: Enum, perm_settings: str) -> None:
+    def perm_settings(self, operator: Enum, perm_settings: str):
         """Filter Settings Permission based on **permSettings** keyword.
 
         Args:
@@ -198,7 +198,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permSettings', operator, perm_settings, TqlType.STRING)
 
-    def perm_tag(self, operator: Enum, perm_tag: str) -> None:
+    def perm_tag(self, operator: Enum, perm_tag: str):
         """Filter Tag Permission based on **permTag** keyword.
 
         Args:
@@ -207,7 +207,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permTag', operator, perm_tag, TqlType.STRING)
 
-    def perm_task(self, operator: Enum, perm_task: str) -> None:
+    def perm_task(self, operator: Enum, perm_task: str):
         """Filter Task Permission based on **permTask** keyword.
 
         Args:
@@ -216,7 +216,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permTask', operator, perm_task, TqlType.STRING)
 
-    def perm_timeline(self, operator: Enum, perm_timeline: str) -> None:
+    def perm_timeline(self, operator: Enum, perm_timeline: str):
         """Filter Timeline Permission based on **permTimeline** keyword.
 
         Args:
@@ -225,7 +225,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permTimeline', operator, perm_timeline, TqlType.STRING)
 
-    def perm_track(self, operator: Enum, perm_track: str) -> None:
+    def perm_track(self, operator: Enum, perm_track: str):
         """Filter Track Permission based on **permTrack** keyword.
 
         Args:
@@ -234,7 +234,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permTrack', operator, perm_track, TqlType.STRING)
 
-    def perm_users(self, operator: Enum, perm_users: str) -> None:
+    def perm_users(self, operator: Enum, perm_users: str):
         """Filter Users Permission based on **permUsers** keyword.
 
         Args:
@@ -243,7 +243,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permUsers', operator, perm_users, TqlType.STRING)
 
-    def perm_victim(self, operator: Enum, perm_victim: str) -> None:
+    def perm_victim(self, operator: Enum, perm_victim: str):
         """Filter Victim Permission based on **permVictim** keyword.
 
         Args:
@@ -252,7 +252,7 @@ class OwnerFilter(FilterABC):
         """
         self._tql.add_filter('permVictim', operator, perm_victim, TqlType.STRING)
 
-    def perm_workflow_template(self, operator: Enum, perm_workflow_template: str) -> None:
+    def perm_workflow_template(self, operator: Enum, perm_workflow_template: str):
         """Filter WorkflowTemplate Permission based on **permWorkflowTemplate** keyword.
 
         Args:
@@ -263,7 +263,7 @@ class OwnerFilter(FilterABC):
             'permWorkflowTemplate', operator, perm_workflow_template, TqlType.STRING
         )
 
-    def user_id(self, operator: Enum, user_id: int) -> None:
+    def user_id(self, operator: Enum, user_id: int):
         """Filter User ID based on **userId** keyword.
 
         Args:

--- a/tcex/api/tc/v3/security/security.py
+++ b/tcex/api/tc/v3/security/security.py
@@ -17,7 +17,7 @@ class Security:
         session: An configured instance of request.Session with TC API Auth.
     """
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: Session):
         """Initialize Class properties."""
         self.session = session
 

--- a/tcex/api/tc/v3/security/system_roles/system_role.py
+++ b/tcex/api/tc/v3/security/system_roles/system_role.py
@@ -26,7 +26,7 @@ class SystemRoles(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -52,7 +52,7 @@ class SystemRoles(ObjectCollectionABC):
 class SystemRole(ObjectABC):
     """SystemRoles Object."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -73,7 +73,7 @@ class SystemRole(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['SystemRoleModel', dict]) -> None:
+    def model(self, data: Union['SystemRoleModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/security/system_roles/system_role_filter.py
+++ b/tcex/api/tc/v3/security/system_roles/system_role_filter.py
@@ -16,7 +16,7 @@ class SystemRoleFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.SYSTEM_ROLES.value
 
-    def active(self, operator: Enum, active: bool) -> None:
+    def active(self, operator: Enum, active: bool):
         """Filter Active based on **active** keyword.
 
         Args:
@@ -25,7 +25,7 @@ class SystemRoleFilter(FilterABC):
         """
         self._tql.add_filter('active', operator, active, TqlType.BOOLEAN)
 
-    def assignable(self, operator: Enum, assignable: bool) -> None:
+    def assignable(self, operator: Enum, assignable: bool):
         """Filter Assignable based on **assignable** keyword.
 
         Args:
@@ -34,7 +34,7 @@ class SystemRoleFilter(FilterABC):
         """
         self._tql.add_filter('assignable', operator, assignable, TqlType.BOOLEAN)
 
-    def displayed(self, operator: Enum, displayed: bool) -> None:
+    def displayed(self, operator: Enum, displayed: bool):
         """Filter Displayed based on **displayed** keyword.
 
         Args:
@@ -43,7 +43,7 @@ class SystemRoleFilter(FilterABC):
         """
         self._tql.add_filter('displayed', operator, displayed, TqlType.BOOLEAN)
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -52,7 +52,7 @@ class SystemRoleFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def name(self, operator: Enum, name: str) -> None:
+    def name(self, operator: Enum, name: str):
         """Filter Name based on **name** keyword.
 
         Args:

--- a/tcex/api/tc/v3/security/user_groups/user_group.py
+++ b/tcex/api/tc/v3/security/user_groups/user_group.py
@@ -26,7 +26,7 @@ class UserGroups(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -52,7 +52,7 @@ class UserGroups(ObjectCollectionABC):
 class UserGroup(ObjectABC):
     """UserGroups Object."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -73,7 +73,7 @@ class UserGroup(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['UserGroupModel', dict]) -> None:
+    def model(self, data: Union['UserGroupModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/security/user_groups/user_group_filter.py
+++ b/tcex/api/tc/v3/security/user_groups/user_group_filter.py
@@ -16,7 +16,7 @@ class UserGroupFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.USER_GROUPS.value
 
-    def description(self, operator: Enum, description: str) -> None:
+    def description(self, operator: Enum, description: str):
         """Filter Description based on **description** keyword.
 
         Args:
@@ -25,7 +25,7 @@ class UserGroupFilter(FilterABC):
         """
         self._tql.add_filter('description', operator, description, TqlType.STRING)
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -34,7 +34,7 @@ class UserGroupFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def name(self, operator: Enum, name: str) -> None:
+    def name(self, operator: Enum, name: str):
         """Filter Name based on **name** keyword.
 
         Args:

--- a/tcex/api/tc/v3/security/users/user.py
+++ b/tcex/api/tc/v3/security/users/user.py
@@ -26,7 +26,7 @@ class Users(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -52,7 +52,7 @@ class Users(ObjectCollectionABC):
 class User(ObjectABC):
     """Users Object."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -73,7 +73,7 @@ class User(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['UserModel', dict]) -> None:
+    def model(self, data: Union['UserModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/security/users/user_filter.py
+++ b/tcex/api/tc/v3/security/users/user_filter.py
@@ -16,7 +16,7 @@ class UserFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.USERS.value
 
-    def first_name(self, operator: Enum, first_name: str) -> None:
+    def first_name(self, operator: Enum, first_name: str):
         """Filter First Name based on **firstName** keyword.
 
         Args:
@@ -25,7 +25,7 @@ class UserFilter(FilterABC):
         """
         self._tql.add_filter('firstName', operator, first_name, TqlType.STRING)
 
-    def group_id(self, operator: Enum, group_id: int) -> None:
+    def group_id(self, operator: Enum, group_id: int):
         """Filter groupID based on **groupId** keyword.
 
         Args:
@@ -34,7 +34,7 @@ class UserFilter(FilterABC):
         """
         self._tql.add_filter('groupId', operator, group_id, TqlType.INTEGER)
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -43,7 +43,7 @@ class UserFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def last_name(self, operator: Enum, last_name: str) -> None:
+    def last_name(self, operator: Enum, last_name: str):
         """Filter Last Name based on **lastName** keyword.
 
         Args:
@@ -52,7 +52,7 @@ class UserFilter(FilterABC):
         """
         self._tql.add_filter('lastName', operator, last_name, TqlType.STRING)
 
-    def user_name(self, operator: Enum, user_name: str) -> None:
+    def user_name(self, operator: Enum, user_name: str):
         """Filter User Name based on **userName** keyword.
 
         Args:

--- a/tcex/api/tc/v3/security_labels/security_label.py
+++ b/tcex/api/tc/v3/security_labels/security_label.py
@@ -30,7 +30,7 @@ class SecurityLabels(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -63,7 +63,7 @@ class SecurityLabel(ObjectABC):
         owner (str, kwargs): The name of the Owner of the Label.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -84,7 +84,7 @@ class SecurityLabel(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['SecurityLabelModel', dict]) -> None:
+    def model(self, data: Union['SecurityLabelModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change
@@ -95,7 +95,7 @@ class SecurityLabel(ObjectABC):
         else:
             raise RuntimeError(f'Invalid data type: {type(data)} provided.')
 
-    def remove(self, params: Optional[dict] = None) -> None:
+    def remove(self, params: Optional[dict] = None):
         """Remove a nested object."""
         method = 'PUT'
         unique_id = self._calculate_unique_id()

--- a/tcex/api/tc/v3/security_labels/security_label_filter.py
+++ b/tcex/api/tc/v3/security_labels/security_label_filter.py
@@ -18,7 +18,7 @@ class SecurityLabelFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.SECURITY_LABELS.value
 
-    def color(self, operator: Enum, color: str) -> None:
+    def color(self, operator: Enum, color: str):
         """Filter Color based on **color** keyword.
 
         Args:
@@ -27,7 +27,7 @@ class SecurityLabelFilter(FilterABC):
         """
         self._tql.add_filter('color', operator, color, TqlType.STRING)
 
-    def date_added(self, operator: Enum, date_added: str) -> None:
+    def date_added(self, operator: Enum, date_added: str):
         """Filter Date Added based on **dateAdded** keyword.
 
         Args:
@@ -37,7 +37,7 @@ class SecurityLabelFilter(FilterABC):
         date_added = self.utils.any_to_datetime(date_added).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateAdded', operator, date_added, TqlType.STRING)
 
-    def description(self, operator: Enum, description: str) -> None:
+    def description(self, operator: Enum, description: str):
         """Filter Description based on **description** keyword.
 
         Args:
@@ -56,7 +56,7 @@ class SecurityLabelFilter(FilterABC):
         self._tql.add_filter('hasGroup', TqlOperator.EQ, groups, TqlType.SUB_QUERY)
         return groups
 
-    def has_group_attribute(self, operator: Enum, has_group_attribute: int) -> None:
+    def has_group_attribute(self, operator: Enum, has_group_attribute: int):
         """Filter Associated Group based on **hasGroupAttribute** keyword.
 
         Args:
@@ -75,7 +75,7 @@ class SecurityLabelFilter(FilterABC):
         self._tql.add_filter('hasIndicator', TqlOperator.EQ, indicators, TqlType.SUB_QUERY)
         return indicators
 
-    def has_indicator_attribute(self, operator: Enum, has_indicator_attribute: int) -> None:
+    def has_indicator_attribute(self, operator: Enum, has_indicator_attribute: int):
         """Filter Associated Indicator based on **hasIndicatorAttribute** keyword.
 
         Args:
@@ -96,7 +96,7 @@ class SecurityLabelFilter(FilterABC):
         self._tql.add_filter('hasVictim', TqlOperator.EQ, victims, TqlType.SUB_QUERY)
         return victims
 
-    def has_victim_attribute(self, operator: Enum, has_victim_attribute: int) -> None:
+    def has_victim_attribute(self, operator: Enum, has_victim_attribute: int):
         """Filter Associated Victim based on **hasVictimAttribute** keyword.
 
         Args:
@@ -105,7 +105,7 @@ class SecurityLabelFilter(FilterABC):
         """
         self._tql.add_filter('hasVictimAttribute', operator, has_victim_attribute, TqlType.INTEGER)
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -114,7 +114,7 @@ class SecurityLabelFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def name(self, operator: Enum, name: str) -> None:
+    def name(self, operator: Enum, name: str):
         """Filter Name based on **name** keyword.
 
         Args:
@@ -123,7 +123,7 @@ class SecurityLabelFilter(FilterABC):
         """
         self._tql.add_filter('name', operator, name, TqlType.STRING)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -132,7 +132,7 @@ class SecurityLabelFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -141,7 +141,7 @@ class SecurityLabelFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def summary(self, operator: Enum, summary: str) -> None:
+    def summary(self, operator: Enum, summary: str):
         """Filter Summary based on **summary** keyword.
 
         Args:
@@ -150,7 +150,7 @@ class SecurityLabelFilter(FilterABC):
         """
         self._tql.add_filter('summary', operator, summary, TqlType.STRING)
 
-    def victim_id(self, operator: Enum, victim_id: int) -> None:
+    def victim_id(self, operator: Enum, victim_id: int):
         """Filter Victim ID based on **victimId** keyword.
 
         Args:

--- a/tcex/api/tc/v3/tags/tag.py
+++ b/tcex/api/tc/v3/tags/tag.py
@@ -27,7 +27,7 @@ class Tags(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -59,7 +59,7 @@ class Tag(ObjectABC):
         owner (str, kwargs): The name of the Owner of the Tag.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -80,7 +80,7 @@ class Tag(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['TagModel', dict]) -> None:
+    def model(self, data: Union['TagModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change
@@ -91,7 +91,7 @@ class Tag(ObjectABC):
         else:
             raise RuntimeError(f'Invalid data type: {type(data)} provided.')
 
-    def remove(self, params: Optional[dict] = None) -> None:
+    def remove(self, params: Optional[dict] = None):
         """Remove a nested object."""
         method = 'PUT'
         unique_id = self._calculate_unique_id()

--- a/tcex/api/tc/v3/tags/tag_filter.py
+++ b/tcex/api/tc/v3/tags/tag_filter.py
@@ -18,7 +18,7 @@ class TagFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.TAGS.value
 
-    def associated_case(self, operator: Enum, associated_case: int) -> None:
+    def associated_case(self, operator: Enum, associated_case: int):
         """Filter associatedCase based on **associatedCase** keyword.
 
         Args:
@@ -27,7 +27,7 @@ class TagFilter(FilterABC):
         """
         self._tql.add_filter('associatedCase', operator, associated_case, TqlType.INTEGER)
 
-    def associated_group(self, operator: Enum, associated_group: int) -> None:
+    def associated_group(self, operator: Enum, associated_group: int):
         """Filter associatedGroup based on **associatedGroup** keyword.
 
         Args:
@@ -36,7 +36,7 @@ class TagFilter(FilterABC):
         """
         self._tql.add_filter('associatedGroup', operator, associated_group, TqlType.INTEGER)
 
-    def associated_indicator(self, operator: Enum, associated_indicator: int) -> None:
+    def associated_indicator(self, operator: Enum, associated_indicator: int):
         """Filter associatedIndicator based on **associatedIndicator** keyword.
 
         Args:
@@ -45,7 +45,7 @@ class TagFilter(FilterABC):
         """
         self._tql.add_filter('associatedIndicator', operator, associated_indicator, TqlType.INTEGER)
 
-    def associated_victim(self, operator: Enum, associated_victim: int) -> None:
+    def associated_victim(self, operator: Enum, associated_victim: int):
         """Filter associatedVictim based on **associatedVictim** keyword.
 
         Args:
@@ -54,7 +54,7 @@ class TagFilter(FilterABC):
         """
         self._tql.add_filter('associatedVictim', operator, associated_victim, TqlType.INTEGER)
 
-    def case_id(self, operator: Enum, case_id: int) -> None:
+    def case_id(self, operator: Enum, case_id: int):
         """Filter Case ID based on **caseId** keyword.
 
         Args:
@@ -63,7 +63,7 @@ class TagFilter(FilterABC):
         """
         self._tql.add_filter('caseId', operator, case_id, TqlType.INTEGER)
 
-    def description(self, operator: Enum, description: str) -> None:
+    def description(self, operator: Enum, description: str):
         """Filter Description based on **description** keyword.
 
         Args:
@@ -112,7 +112,7 @@ class TagFilter(FilterABC):
         self._tql.add_filter('hasVictim', TqlOperator.EQ, victims, TqlType.SUB_QUERY)
         return victims
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -121,7 +121,7 @@ class TagFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def last_used(self, operator: Enum, last_used: str) -> None:
+    def last_used(self, operator: Enum, last_used: str):
         """Filter LastUsed based on **lastUsed** keyword.
 
         Args:
@@ -131,7 +131,7 @@ class TagFilter(FilterABC):
         last_used = self.utils.any_to_datetime(last_used).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('lastUsed', operator, last_used, TqlType.STRING)
 
-    def name(self, operator: Enum, name: str) -> None:
+    def name(self, operator: Enum, name: str):
         """Filter Name based on **name** keyword.
 
         Args:
@@ -140,7 +140,7 @@ class TagFilter(FilterABC):
         """
         self._tql.add_filter('name', operator, name, TqlType.STRING)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -149,7 +149,7 @@ class TagFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -158,7 +158,7 @@ class TagFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def summary(self, operator: Enum, summary: str) -> None:
+    def summary(self, operator: Enum, summary: str):
         """Filter Summary based on **summary** keyword.
 
         Args:

--- a/tcex/api/tc/v3/tasks/task.py
+++ b/tcex/api/tc/v3/tasks/task.py
@@ -35,7 +35,7 @@ class Tasks(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -80,7 +80,7 @@ class Task(ObjectABC):
         xid (str, kwargs): The **xid** for the Task.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -101,7 +101,7 @@ class Task(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['TaskModel', dict]) -> None:
+    def model(self, data: Union['TaskModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change
@@ -135,7 +135,7 @@ class Task(ObjectABC):
 
         yield from self._iterate_over_sublist(Notes)
 
-    def stage_artifact(self, data: Union[dict, 'ObjectABC', 'ArtifactModel']) -> None:
+    def stage_artifact(self, data: Union[dict, 'ObjectABC', 'ArtifactModel']):
         """Stage artifact on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -148,7 +148,7 @@ class Task(ObjectABC):
         self.model.artifacts.data.append(data)
 
     # pylint: disable=redefined-builtin
-    def stage_assignee(self, type: str, data: Union[dict, 'ObjectABC', 'ArtifactModel']) -> None:
+    def stage_assignee(self, type: str, data: Union[dict, 'ObjectABC', 'ArtifactModel']):
         """Stage artifact on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -164,7 +164,7 @@ class Task(ObjectABC):
         self.model.assignee.type = type
         self.model.assignee.data = data
 
-    def stage_note(self, data: Union[dict, 'ObjectABC', 'NoteModel']) -> None:
+    def stage_note(self, data: Union[dict, 'ObjectABC', 'NoteModel']):
         """Stage note on the object."""
         if isinstance(data, ObjectABC):
             data = data.model

--- a/tcex/api/tc/v3/tasks/task_filter.py
+++ b/tcex/api/tc/v3/tasks/task_filter.py
@@ -18,7 +18,7 @@ class TaskFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.TASKS.value
 
-    def assigned_to_user_or_group(self, operator: Enum, assigned_to_user_or_group: str) -> None:
+    def assigned_to_user_or_group(self, operator: Enum, assigned_to_user_or_group: str):
         """Filter Assigned To User or Group based on **assignedToUserOrGroup** keyword.
 
         Args:
@@ -29,7 +29,7 @@ class TaskFilter(FilterABC):
             'assignedToUserOrGroup', operator, assigned_to_user_or_group, TqlType.STRING
         )
 
-    def assignee_name(self, operator: Enum, assignee_name: str) -> None:
+    def assignee_name(self, operator: Enum, assignee_name: str):
         """Filter Assignee Name based on **assigneeName** keyword.
 
         Args:
@@ -38,7 +38,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('assigneeName', operator, assignee_name, TqlType.STRING)
 
-    def automated(self, operator: Enum, automated: bool) -> None:
+    def automated(self, operator: Enum, automated: bool):
         """Filter Automated based on **automated** keyword.
 
         Args:
@@ -47,7 +47,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('automated', operator, automated, TqlType.BOOLEAN)
 
-    def case_id(self, operator: Enum, case_id: int) -> None:
+    def case_id(self, operator: Enum, case_id: int):
         """Filter Case ID based on **caseId** keyword.
 
         Args:
@@ -56,7 +56,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('caseId', operator, case_id, TqlType.INTEGER)
 
-    def case_id_as_string(self, operator: Enum, case_id_as_string: str) -> None:
+    def case_id_as_string(self, operator: Enum, case_id_as_string: str):
         """Filter CaseID As String based on **caseIdAsString** keyword.
 
         Args:
@@ -65,7 +65,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('caseIdAsString', operator, case_id_as_string, TqlType.STRING)
 
-    def case_severity(self, operator: Enum, case_severity: str) -> None:
+    def case_severity(self, operator: Enum, case_severity: str):
         """Filter Case Severity based on **caseSeverity** keyword.
 
         Args:
@@ -74,7 +74,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('caseSeverity', operator, case_severity, TqlType.STRING)
 
-    def completed_by(self, operator: Enum, completed_by: str) -> None:
+    def completed_by(self, operator: Enum, completed_by: str):
         """Filter Completed By based on **completedBy** keyword.
 
         Args:
@@ -83,7 +83,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('completedBy', operator, completed_by, TqlType.STRING)
 
-    def completed_date(self, operator: Enum, completed_date: str) -> None:
+    def completed_date(self, operator: Enum, completed_date: str):
         """Filter Completed Date based on **completedDate** keyword.
 
         Args:
@@ -93,7 +93,7 @@ class TaskFilter(FilterABC):
         completed_date = self.utils.any_to_datetime(completed_date).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('completedDate', operator, completed_date, TqlType.STRING)
 
-    def description(self, operator: Enum, description: str) -> None:
+    def description(self, operator: Enum, description: str):
         """Filter Description based on **description** keyword.
 
         Args:
@@ -102,7 +102,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('description', operator, description, TqlType.STRING)
 
-    def due_date(self, operator: Enum, due_date: str) -> None:
+    def due_date(self, operator: Enum, due_date: str):
         """Filter Due Date based on **dueDate** keyword.
 
         Args:
@@ -142,7 +142,7 @@ class TaskFilter(FilterABC):
         self._tql.add_filter('hasNote', TqlOperator.EQ, notes, TqlType.SUB_QUERY)
         return notes
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -151,7 +151,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def name(self, operator: Enum, name: str) -> None:
+    def name(self, operator: Enum, name: str):
         """Filter Name based on **name** keyword.
 
         Args:
@@ -160,7 +160,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('name', operator, name, TqlType.STRING)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -169,7 +169,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -178,7 +178,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def required(self, operator: Enum, required: bool) -> None:
+    def required(self, operator: Enum, required: bool):
         """Filter Required based on **required** keyword.
 
         Args:
@@ -187,7 +187,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('required', operator, required, TqlType.BOOLEAN)
 
-    def status(self, operator: Enum, status: str) -> None:
+    def status(self, operator: Enum, status: str):
         """Filter Status based on **status** keyword.
 
         Args:
@@ -196,7 +196,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('status', operator, status, TqlType.STRING)
 
-    def target_id(self, operator: Enum, target_id: int) -> None:
+    def target_id(self, operator: Enum, target_id: int):
         """Filter Assignee based on **targetId** keyword.
 
         Args:
@@ -205,7 +205,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('targetId', operator, target_id, TqlType.INTEGER)
 
-    def target_type(self, operator: Enum, target_type: str) -> None:
+    def target_type(self, operator: Enum, target_type: str):
         """Filter Target Type based on **targetType** keyword.
 
         Args:
@@ -214,7 +214,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('targetType', operator, target_type, TqlType.STRING)
 
-    def workflow_phase(self, operator: Enum, workflow_phase: int) -> None:
+    def workflow_phase(self, operator: Enum, workflow_phase: int):
         """Filter Workflow Phase based on **workflowPhase** keyword.
 
         Args:
@@ -223,7 +223,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('workflowPhase', operator, workflow_phase, TqlType.INTEGER)
 
-    def workflow_step(self, operator: Enum, workflow_step: int) -> None:
+    def workflow_step(self, operator: Enum, workflow_step: int):
         """Filter Workflow Step based on **workflowStep** keyword.
 
         Args:
@@ -232,7 +232,7 @@ class TaskFilter(FilterABC):
         """
         self._tql.add_filter('workflowStep', operator, workflow_step, TqlType.INTEGER)
 
-    def xid(self, operator: Enum, xid: str) -> None:
+    def xid(self, operator: Enum, xid: str):
         """Filter XID based on **xid** keyword.
 
         Args:

--- a/tcex/api/tc/v3/threat_intelligence/threat_intelligence.py
+++ b/tcex/api/tc/v3/threat_intelligence/threat_intelligence.py
@@ -24,7 +24,7 @@ class ThreatIntelligence:
         session: An configured instance of request.Session with TC API Auth.
     """
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: Session):
         """Initialize Class properties."""
         self.session = session
         self._ti_utils = None

--- a/tcex/api/tc/v3/tql/tql.py
+++ b/tcex/api/tc/v3/tql/tql.py
@@ -9,7 +9,7 @@ from tcex.api.tc.v3.tql.tql_type import TqlType
 class Tql:
     """ThreatConnect TQL"""
 
-    def __init__(self) -> None:
+    def __init__(self):
         """Initialize Class Properties"""
         self._filters = []
         self.raw_tql = None
@@ -44,13 +44,13 @@ class Tql:
         return self._filters
 
     @filters.setter
-    def filters(self, filters: List[dict]) -> None:
+    def filters(self, filters: List[dict]):
         """Set the filters"""
         self._filters = filters
 
     def add_filter(
         self, keyword: str, operator: str, value: str, type_: Optional[TqlType] = TqlType.STRING
-    ) -> None:
+    ):
         """Add a filter to the current obj
 
         Args:
@@ -63,6 +63,6 @@ class Tql:
             {'keyword': keyword, 'operator': operator, 'value': value, 'type': type_}
         )
 
-    def set_raw_tql(self, tql: str) -> None:
+    def set_raw_tql(self, tql: str):
         """Set a raw TQL filter"""
         self.raw_tql = tql

--- a/tcex/api/tc/v3/victim_assets/victim_asset.py
+++ b/tcex/api/tc/v3/victim_assets/victim_asset.py
@@ -31,7 +31,7 @@ class VictimAssets(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -71,7 +71,7 @@ class VictimAsset(ObjectABC):
         website (str, kwargs): The website of the asset.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -92,7 +92,7 @@ class VictimAsset(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['VictimAssetModel', dict]) -> None:
+    def model(self, data: Union['VictimAssetModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change
@@ -111,7 +111,7 @@ class VictimAsset(ObjectABC):
 
         yield from self._iterate_over_sublist(Groups)
 
-    def stage_associated_group(self, data: Union[dict, 'ObjectABC', 'GroupModel']) -> None:
+    def stage_associated_group(self, data: Union[dict, 'ObjectABC', 'GroupModel']):
         """Stage group on the object."""
         if isinstance(data, ObjectABC):
             data = data.model

--- a/tcex/api/tc/v3/victim_assets/victim_asset_filter.py
+++ b/tcex/api/tc/v3/victim_assets/victim_asset_filter.py
@@ -18,7 +18,7 @@ class VictimAssetFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.VICTIM_ASSETS.value
 
-    def asset(self, operator: Enum, asset: str) -> None:
+    def asset(self, operator: Enum, asset: str):
         """Filter Asset based on **asset** keyword.
 
         Args:
@@ -27,7 +27,7 @@ class VictimAssetFilter(FilterABC):
         """
         self._tql.add_filter('asset', operator, asset, TqlType.STRING)
 
-    def associated_group(self, operator: Enum, associated_group: int) -> None:
+    def associated_group(self, operator: Enum, associated_group: int):
         """Filter associatedGroup based on **associatedGroup** keyword.
 
         Args:
@@ -73,7 +73,7 @@ class VictimAssetFilter(FilterABC):
         self._tql.add_filter('hasVictimAsset', TqlOperator.EQ, victim_assets, TqlType.SUB_QUERY)
         return victim_assets
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -82,7 +82,7 @@ class VictimAssetFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -91,7 +91,7 @@ class VictimAssetFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -100,7 +100,7 @@ class VictimAssetFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def summary(self, operator: Enum, summary: str) -> None:
+    def summary(self, operator: Enum, summary: str):
         """Filter Summary based on **summary** keyword.
 
         Args:
@@ -109,7 +109,7 @@ class VictimAssetFilter(FilterABC):
         """
         self._tql.add_filter('summary', operator, summary, TqlType.STRING)
 
-    def type(self, operator: Enum, type: int) -> None:  # pylint: disable=redefined-builtin
+    def type(self, operator: Enum, type: int):  # pylint: disable=redefined-builtin
         """Filter Type ID based on **type** keyword.
 
         Args:
@@ -118,7 +118,7 @@ class VictimAssetFilter(FilterABC):
         """
         self._tql.add_filter('type', operator, type, TqlType.INTEGER)
 
-    def type_name(self, operator: Enum, type_name: str) -> None:
+    def type_name(self, operator: Enum, type_name: str):
         """Filter Type Name based on **typeName** keyword.
 
         Args:
@@ -127,7 +127,7 @@ class VictimAssetFilter(FilterABC):
         """
         self._tql.add_filter('typeName', operator, type_name, TqlType.STRING)
 
-    def victim_id(self, operator: Enum, victim_id: int) -> None:
+    def victim_id(self, operator: Enum, victim_id: int):
         """Filter Victim ID based on **victimId** keyword.
 
         Args:
@@ -136,7 +136,7 @@ class VictimAssetFilter(FilterABC):
         """
         self._tql.add_filter('victimId', operator, victim_id, TqlType.INTEGER)
 
-    def victim_name(self, operator: Enum, victim_name: str) -> None:
+    def victim_name(self, operator: Enum, victim_name: str):
         """Filter Victim Name based on **victimName** keyword.
 
         Args:

--- a/tcex/api/tc/v3/victim_attributes/victim_attribute.py
+++ b/tcex/api/tc/v3/victim_attributes/victim_attribute.py
@@ -29,7 +29,7 @@ class VictimAttributes(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -64,7 +64,7 @@ class VictimAttribute(ObjectABC):
         victim_id (int, kwargs): Victim associated with attribute.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -85,7 +85,7 @@ class VictimAttribute(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['VictimAttributeModel', dict]) -> None:
+    def model(self, data: Union['VictimAttributeModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/victim_attributes/victim_attribute_filter.py
+++ b/tcex/api/tc/v3/victim_attributes/victim_attribute_filter.py
@@ -18,7 +18,7 @@ class VictimAttributeFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.VICTIM_ATTRIBUTES.value
 
-    def date_added(self, operator: Enum, date_added: str) -> None:
+    def date_added(self, operator: Enum, date_added: str):
         """Filter Date Added based on **dateAdded** keyword.
 
         Args:
@@ -28,7 +28,7 @@ class VictimAttributeFilter(FilterABC):
         date_added = self.utils.any_to_datetime(date_added).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateAdded', operator, date_added, TqlType.STRING)
 
-    def date_val(self, operator: Enum, date_val: str) -> None:
+    def date_val(self, operator: Enum, date_val: str):
         """Filter Date based on **dateVal** keyword.
 
         Args:
@@ -38,7 +38,7 @@ class VictimAttributeFilter(FilterABC):
         date_val = self.utils.any_to_datetime(date_val).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateVal', operator, date_val, TqlType.STRING)
 
-    def displayed(self, operator: Enum, displayed: bool) -> None:
+    def displayed(self, operator: Enum, displayed: bool):
         """Filter Displayed based on **displayed** keyword.
 
         Args:
@@ -67,7 +67,7 @@ class VictimAttributeFilter(FilterABC):
         self._tql.add_filter('hasVictim', TqlOperator.EQ, victims, TqlType.SUB_QUERY)
         return victims
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -76,7 +76,7 @@ class VictimAttributeFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def int_val(self, operator: Enum, int_val: int) -> None:
+    def int_val(self, operator: Enum, int_val: int):
         """Filter Integer Value based on **intVal** keyword.
 
         Args:
@@ -85,7 +85,7 @@ class VictimAttributeFilter(FilterABC):
         """
         self._tql.add_filter('intVal', operator, int_val, TqlType.INTEGER)
 
-    def last_modified(self, operator: Enum, last_modified: str) -> None:
+    def last_modified(self, operator: Enum, last_modified: str):
         """Filter Last Modified based on **lastModified** keyword.
 
         Args:
@@ -95,7 +95,7 @@ class VictimAttributeFilter(FilterABC):
         last_modified = self.utils.any_to_datetime(last_modified).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('lastModified', operator, last_modified, TqlType.STRING)
 
-    def max_size(self, operator: Enum, max_size: int) -> None:
+    def max_size(self, operator: Enum, max_size: int):
         """Filter Max Size based on **maxSize** keyword.
 
         Args:
@@ -104,7 +104,7 @@ class VictimAttributeFilter(FilterABC):
         """
         self._tql.add_filter('maxSize', operator, max_size, TqlType.INTEGER)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -113,7 +113,7 @@ class VictimAttributeFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -122,7 +122,7 @@ class VictimAttributeFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def source(self, operator: Enum, source: str) -> None:
+    def source(self, operator: Enum, source: str):
         """Filter Source based on **source** keyword.
 
         Args:
@@ -131,7 +131,7 @@ class VictimAttributeFilter(FilterABC):
         """
         self._tql.add_filter('source', operator, source, TqlType.STRING)
 
-    def text(self, operator: Enum, text: str) -> None:
+    def text(self, operator: Enum, text: str):
         """Filter Text based on **text** keyword.
 
         Args:
@@ -140,7 +140,7 @@ class VictimAttributeFilter(FilterABC):
         """
         self._tql.add_filter('text', operator, text, TqlType.STRING)
 
-    def type(self, operator: Enum, type: int) -> None:  # pylint: disable=redefined-builtin
+    def type(self, operator: Enum, type: int):  # pylint: disable=redefined-builtin
         """Filter Type ID based on **type** keyword.
 
         Args:
@@ -149,7 +149,7 @@ class VictimAttributeFilter(FilterABC):
         """
         self._tql.add_filter('type', operator, type, TqlType.INTEGER)
 
-    def type_name(self, operator: Enum, type_name: str) -> None:
+    def type_name(self, operator: Enum, type_name: str):
         """Filter Type Name based on **typeName** keyword.
 
         Args:
@@ -158,7 +158,7 @@ class VictimAttributeFilter(FilterABC):
         """
         self._tql.add_filter('typeName', operator, type_name, TqlType.STRING)
 
-    def user(self, operator: Enum, user: str) -> None:
+    def user(self, operator: Enum, user: str):
         """Filter User based on **user** keyword.
 
         Args:
@@ -167,7 +167,7 @@ class VictimAttributeFilter(FilterABC):
         """
         self._tql.add_filter('user', operator, user, TqlType.STRING)
 
-    def victim_id(self, operator: Enum, victim_id: int) -> None:
+    def victim_id(self, operator: Enum, victim_id: int):
         """Filter Victim ID based on **victimId** keyword.
 
         Args:

--- a/tcex/api/tc/v3/victims/victim.py
+++ b/tcex/api/tc/v3/victims/victim.py
@@ -38,7 +38,7 @@ class Victims(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -80,7 +80,7 @@ class Victim(ObjectABC):
         work_location (str, kwargs): Work location of the Victim.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -101,7 +101,7 @@ class Victim(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['VictimModel', dict]) -> None:
+    def model(self, data: Union['VictimModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change
@@ -159,7 +159,7 @@ class Victim(ObjectABC):
 
         yield from self._iterate_over_sublist(Tags)
 
-    def stage_victim_asset(self, data: Union[dict, 'ObjectABC', 'VictimAssetModel']) -> None:
+    def stage_victim_asset(self, data: Union[dict, 'ObjectABC', 'VictimAssetModel']):
         """Stage victim_asset on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -171,7 +171,7 @@ class Victim(ObjectABC):
         data._staged = True
         self.model.assets.data.append(data)
 
-    def stage_attribute(self, data: Union[dict, 'ObjectABC', 'VictimAttributeModel']) -> None:
+    def stage_attribute(self, data: Union[dict, 'ObjectABC', 'VictimAttributeModel']):
         """Stage attribute on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -183,7 +183,7 @@ class Victim(ObjectABC):
         data._staged = True
         self.model.attributes.data.append(data)
 
-    def stage_security_label(self, data: Union[dict, 'ObjectABC', 'SecurityLabelModel']) -> None:
+    def stage_security_label(self, data: Union[dict, 'ObjectABC', 'SecurityLabelModel']):
         """Stage security_label on the object."""
         if isinstance(data, ObjectABC):
             data = data.model
@@ -195,7 +195,7 @@ class Victim(ObjectABC):
         data._staged = True
         self.model.security_labels.data.append(data)
 
-    def stage_tag(self, data: Union[dict, 'ObjectABC', 'TagModel']) -> None:
+    def stage_tag(self, data: Union[dict, 'ObjectABC', 'TagModel']):
         """Stage tag on the object."""
         if isinstance(data, ObjectABC):
             data = data.model

--- a/tcex/api/tc/v3/victims/victim_filter.py
+++ b/tcex/api/tc/v3/victims/victim_filter.py
@@ -18,7 +18,7 @@ class VictimFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.VICTIMS.value
 
-    def asset_name(self, operator: Enum, asset_name: str) -> None:
+    def asset_name(self, operator: Enum, asset_name: str):
         """Filter Asset Name based on **assetName** keyword.
 
         Args:
@@ -27,7 +27,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('assetName', operator, asset_name, TqlType.STRING)
 
-    def asset_type(self, operator: Enum, asset_type: int) -> None:
+    def asset_type(self, operator: Enum, asset_type: int):
         """Filter Asset Type ID based on **assetType** keyword.
 
         Args:
@@ -36,7 +36,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('assetType', operator, asset_type, TqlType.INTEGER)
 
-    def asset_typename(self, operator: Enum, asset_typename: str) -> None:
+    def asset_typename(self, operator: Enum, asset_typename: str):
         """Filter Asset Type Name based on **assetTypename** keyword.
 
         Args:
@@ -45,7 +45,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('assetTypename', operator, asset_typename, TqlType.STRING)
 
-    def attribute(self, operator: Enum, attribute: str) -> None:
+    def attribute(self, operator: Enum, attribute: str):
         """Filter attribute based on **attribute** keyword.
 
         Args:
@@ -54,7 +54,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('attribute', operator, attribute, TqlType.STRING)
 
-    def description(self, operator: Enum, description: str) -> None:
+    def description(self, operator: Enum, description: str):
         """Filter Description based on **description** keyword.
 
         Args:
@@ -130,7 +130,7 @@ class VictimFilter(FilterABC):
         self._tql.add_filter('hasVictimAsset', TqlOperator.EQ, victim_assets, TqlType.SUB_QUERY)
         return victim_assets
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -139,7 +139,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def name(self, operator: Enum, name: str) -> None:
+    def name(self, operator: Enum, name: str):
         """Filter Name based on **name** keyword.
 
         Args:
@@ -148,7 +148,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('name', operator, name, TqlType.STRING)
 
-    def nationality(self, operator: Enum, nationality: str) -> None:
+    def nationality(self, operator: Enum, nationality: str):
         """Filter Nationality based on **nationality** keyword.
 
         Args:
@@ -157,7 +157,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('nationality', operator, nationality, TqlType.STRING)
 
-    def organization(self, operator: Enum, organization: str) -> None:
+    def organization(self, operator: Enum, organization: str):
         """Filter Organization based on **organization** keyword.
 
         Args:
@@ -166,7 +166,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('organization', operator, organization, TqlType.STRING)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -175,7 +175,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -184,7 +184,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def security_label(self, operator: Enum, security_label: str) -> None:
+    def security_label(self, operator: Enum, security_label: str):
         """Filter Security Label based on **securityLabel** keyword.
 
         Args:
@@ -193,7 +193,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('securityLabel', operator, security_label, TqlType.STRING)
 
-    def sub_org(self, operator: Enum, sub_org: str) -> None:
+    def sub_org(self, operator: Enum, sub_org: str):
         """Filter Sub-organization based on **subOrg** keyword.
 
         Args:
@@ -202,7 +202,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('subOrg', operator, sub_org, TqlType.STRING)
 
-    def summary(self, operator: Enum, summary: str) -> None:
+    def summary(self, operator: Enum, summary: str):
         """Filter Summary based on **summary** keyword.
 
         Args:
@@ -211,7 +211,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('summary', operator, summary, TqlType.STRING)
 
-    def tag(self, operator: Enum, tag: str) -> None:
+    def tag(self, operator: Enum, tag: str):
         """Filter Tag based on **tag** keyword.
 
         Args:
@@ -220,7 +220,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('tag', operator, tag, TqlType.STRING)
 
-    def tag_owner(self, operator: Enum, tag_owner: int) -> None:
+    def tag_owner(self, operator: Enum, tag_owner: int):
         """Filter Tag Owner ID based on **tagOwner** keyword.
 
         Args:
@@ -229,7 +229,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('tagOwner', operator, tag_owner, TqlType.INTEGER)
 
-    def tag_owner_name(self, operator: Enum, tag_owner_name: str) -> None:
+    def tag_owner_name(self, operator: Enum, tag_owner_name: str):
         """Filter Tag Owner Name based on **tagOwnerName** keyword.
 
         Args:
@@ -238,7 +238,7 @@ class VictimFilter(FilterABC):
         """
         self._tql.add_filter('tagOwnerName', operator, tag_owner_name, TqlType.STRING)
 
-    def work_location(self, operator: Enum, work_location: str) -> None:
+    def work_location(self, operator: Enum, work_location: str):
         """Filter Work Location based on **workLocation** keyword.
 
         Args:

--- a/tcex/api/tc/v3/workflow_events/workflow_event.py
+++ b/tcex/api/tc/v3/workflow_events/workflow_event.py
@@ -34,7 +34,7 @@ class WorkflowEvents(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -70,7 +70,7 @@ class WorkflowEvent(ObjectABC):
         summary (str, kwargs): The **summary** for the Workflow_Event.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -91,7 +91,7 @@ class WorkflowEvent(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['WorkflowEventModel', dict]) -> None:
+    def model(self, data: Union['WorkflowEventModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change
@@ -117,7 +117,7 @@ class WorkflowEvent(ObjectABC):
 
         yield from self._iterate_over_sublist(Notes)
 
-    def stage_note(self, data: Union[dict, 'ObjectABC', 'NoteModel']) -> None:
+    def stage_note(self, data: Union[dict, 'ObjectABC', 'NoteModel']):
         """Stage note on the object."""
         if isinstance(data, ObjectABC):
             data = data.model

--- a/tcex/api/tc/v3/workflow_events/workflow_event_filter.py
+++ b/tcex/api/tc/v3/workflow_events/workflow_event_filter.py
@@ -16,7 +16,7 @@ class WorkflowEventFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.WORKFLOW_EVENTS.value
 
-    def case_id(self, operator: Enum, case_id: int) -> None:
+    def case_id(self, operator: Enum, case_id: int):
         """Filter Case ID based on **caseId** keyword.
 
         Args:
@@ -25,7 +25,7 @@ class WorkflowEventFilter(FilterABC):
         """
         self._tql.add_filter('caseId', operator, case_id, TqlType.INTEGER)
 
-    def date_added(self, operator: Enum, date_added: str) -> None:
+    def date_added(self, operator: Enum, date_added: str):
         """Filter Date Added based on **dateAdded** keyword.
 
         Args:
@@ -35,7 +35,7 @@ class WorkflowEventFilter(FilterABC):
         date_added = self.utils.any_to_datetime(date_added).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('dateAdded', operator, date_added, TqlType.STRING)
 
-    def deleted(self, operator: Enum, deleted: bool) -> None:
+    def deleted(self, operator: Enum, deleted: bool):
         """Filter Deleted based on **deleted** keyword.
 
         Args:
@@ -44,7 +44,7 @@ class WorkflowEventFilter(FilterABC):
         """
         self._tql.add_filter('deleted', operator, deleted, TqlType.BOOLEAN)
 
-    def deleted_reason(self, operator: Enum, deleted_reason: str) -> None:
+    def deleted_reason(self, operator: Enum, deleted_reason: str):
         """Filter Deleted Reason based on **deletedReason** keyword.
 
         Args:
@@ -53,7 +53,7 @@ class WorkflowEventFilter(FilterABC):
         """
         self._tql.add_filter('deletedReason', operator, deleted_reason, TqlType.STRING)
 
-    def event_date(self, operator: Enum, event_date: str) -> None:
+    def event_date(self, operator: Enum, event_date: str):
         """Filter Event Date based on **eventDate** keyword.
 
         Args:
@@ -63,7 +63,7 @@ class WorkflowEventFilter(FilterABC):
         event_date = self.utils.any_to_datetime(event_date).strftime('%Y-%m-%dT%H:%M:%S')
         self._tql.add_filter('eventDate', operator, event_date, TqlType.STRING)
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -72,7 +72,7 @@ class WorkflowEventFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def link(self, operator: Enum, link: str) -> None:
+    def link(self, operator: Enum, link: str):
         """Filter Link based on **link** keyword.
 
         Args:
@@ -81,7 +81,7 @@ class WorkflowEventFilter(FilterABC):
         """
         self._tql.add_filter('link', operator, link, TqlType.STRING)
 
-    def summary(self, operator: Enum, summary: str) -> None:
+    def summary(self, operator: Enum, summary: str):
         """Filter Summary based on **summary** keyword.
 
         Args:
@@ -90,7 +90,7 @@ class WorkflowEventFilter(FilterABC):
         """
         self._tql.add_filter('summary', operator, summary, TqlType.STRING)
 
-    def system_generated(self, operator: Enum, system_generated: bool) -> None:
+    def system_generated(self, operator: Enum, system_generated: bool):
         """Filter System Generated based on **systemGenerated** keyword.
 
         Args:
@@ -100,7 +100,7 @@ class WorkflowEventFilter(FilterABC):
         """
         self._tql.add_filter('systemGenerated', operator, system_generated, TqlType.BOOLEAN)
 
-    def user_name(self, operator: Enum, user_name: str) -> None:
+    def user_name(self, operator: Enum, user_name: str):
         """Filter User Name based on **userName** keyword.
 
         Args:

--- a/tcex/api/tc/v3/workflow_templates/workflow_template.py
+++ b/tcex/api/tc/v3/workflow_templates/workflow_template.py
@@ -29,7 +29,7 @@ class WorkflowTemplates(ObjectCollectionABC):
         params (dict): Additional query params (see example above).
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(
             kwargs.pop('session', None), kwargs.pop('tql_filter', None), kwargs.pop('params', None)
@@ -62,7 +62,7 @@ class WorkflowTemplate(ObjectABC):
         version (int, kwargs): The **version** for the Workflow_Template.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         """Initialize class properties."""
         super().__init__(kwargs.pop('session', None))
 
@@ -83,7 +83,7 @@ class WorkflowTemplate(ObjectABC):
         return self._model
 
     @model.setter
-    def model(self, data: Union['WorkflowTemplateModel', dict]) -> None:
+    def model(self, data: Union['WorkflowTemplateModel', dict]):
         """Create model using the provided data."""
         if isinstance(data, type(self.model)):
             # provided data is already a model, nothing required to change

--- a/tcex/api/tc/v3/workflow_templates/workflow_template_filter.py
+++ b/tcex/api/tc/v3/workflow_templates/workflow_template_filter.py
@@ -16,7 +16,7 @@ class WorkflowTemplateFilter(FilterABC):
         """Return the API endpoint."""
         return ApiEndpoints.WORKFLOW_TEMPLATES.value
 
-    def active(self, operator: Enum, active: bool) -> None:
+    def active(self, operator: Enum, active: bool):
         """Filter Active based on **active** keyword.
 
         Args:
@@ -25,7 +25,7 @@ class WorkflowTemplateFilter(FilterABC):
         """
         self._tql.add_filter('active', operator, active, TqlType.BOOLEAN)
 
-    def description(self, operator: Enum, description: str) -> None:
+    def description(self, operator: Enum, description: str):
         """Filter Description based on **description** keyword.
 
         Args:
@@ -34,7 +34,7 @@ class WorkflowTemplateFilter(FilterABC):
         """
         self._tql.add_filter('description', operator, description, TqlType.STRING)
 
-    def id(self, operator: Enum, id: int) -> None:  # pylint: disable=redefined-builtin
+    def id(self, operator: Enum, id: int):  # pylint: disable=redefined-builtin
         """Filter ID based on **id** keyword.
 
         Args:
@@ -43,7 +43,7 @@ class WorkflowTemplateFilter(FilterABC):
         """
         self._tql.add_filter('id', operator, id, TqlType.INTEGER)
 
-    def name(self, operator: Enum, name: str) -> None:
+    def name(self, operator: Enum, name: str):
         """Filter Name based on **name** keyword.
 
         Args:
@@ -52,7 +52,7 @@ class WorkflowTemplateFilter(FilterABC):
         """
         self._tql.add_filter('name', operator, name, TqlType.STRING)
 
-    def owner(self, operator: Enum, owner: int) -> None:
+    def owner(self, operator: Enum, owner: int):
         """Filter Owner ID based on **owner** keyword.
 
         Args:
@@ -61,7 +61,7 @@ class WorkflowTemplateFilter(FilterABC):
         """
         self._tql.add_filter('owner', operator, owner, TqlType.INTEGER)
 
-    def owner_name(self, operator: Enum, owner_name: str) -> None:
+    def owner_name(self, operator: Enum, owner_name: str):
         """Filter Owner Name based on **ownerName** keyword.
 
         Args:
@@ -70,7 +70,7 @@ class WorkflowTemplateFilter(FilterABC):
         """
         self._tql.add_filter('ownerName', operator, owner_name, TqlType.STRING)
 
-    def target_id(self, operator: Enum, target_id: int) -> None:
+    def target_id(self, operator: Enum, target_id: int):
         """Filter Target ID based on **targetId** keyword.
 
         Args:
@@ -79,7 +79,7 @@ class WorkflowTemplateFilter(FilterABC):
         """
         self._tql.add_filter('targetId', operator, target_id, TqlType.INTEGER)
 
-    def target_type(self, operator: Enum, target_type: str) -> None:
+    def target_type(self, operator: Enum, target_type: str):
         """Filter Target Type based on **targetType** keyword.
 
         Args:
@@ -88,7 +88,7 @@ class WorkflowTemplateFilter(FilterABC):
         """
         self._tql.add_filter('targetType', operator, target_type, TqlType.STRING)
 
-    def version(self, operator: Enum, version: int) -> None:
+    def version(self, operator: Enum, version: int):
         """Filter Version based on **version** keyword.
 
         Args:

--- a/tcex/app_config/__init__.py
+++ b/tcex/app_config/__init__.py
@@ -5,5 +5,4 @@ from tcex.app_config.app_spec_yml import AppSpecYml
 from tcex.app_config.install_json import InstallJson
 from tcex.app_config.job_json import JobJson
 from tcex.app_config.layout_json import LayoutJson
-from tcex.app_config.permutation import Permutation
 from tcex.app_config.tcex_json import TcexJson

--- a/tcex/app_config/app_spec_yml.py
+++ b/tcex/app_config/app_spec_yml.py
@@ -32,7 +32,7 @@ class AppSpecYml:
         filename: Optional[str] = None,
         path: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-    ) -> None:
+    ):
         """Initialize class properties."""
         filename = filename or 'app_spec.yml'
         path = path or os.getcwd()
@@ -174,7 +174,7 @@ class AppSpecYml:
             ],
         }
 
-    def _migrate_schema_100_to_110(self, contents: dict) -> None:
+    def _migrate_schema_100_to_110(self, contents: dict):
         """Migrate 1.0.0 schema to 1.1.0 schema."""
         # moved app.* to top level
         self._migrate_schema_100_to_110_app(contents)
@@ -216,7 +216,7 @@ class AppSpecYml:
         self.rewrite_contents(contents)
 
     @staticmethod
-    def _migrate_schema_100_to_110_app(contents: dict) -> None:
+    def _migrate_schema_100_to_110_app(contents: dict):
         """Migrate 1.0.0 schema to 1.1.0 schema."""
         # remove "app" top level
         for k, v in dict(contents).get('app').items():
@@ -230,14 +230,14 @@ class AppSpecYml:
         del contents['app']
 
     @staticmethod
-    def _migrate_schema_100_to_110_organization_feeds(contents: dict) -> None:
+    def _migrate_schema_100_to_110_organization_feeds(contents: dict):
         """Migrate 1.0.0 schema to 1.1.0 schema."""
         if contents.get('feeds') is not None and contents['runtimeLevel'].lower() == 'organization':
             contents.setdefault('organization', {})
             contents['organization']['feeds'] = contents.pop('feeds', [])
 
     @staticmethod
-    def _migrate_schema_100_to_110_organization_repeating_minutes(contents: dict) -> None:
+    def _migrate_schema_100_to_110_organization_repeating_minutes(contents: dict):
         """Migrate 1.0.0 schema to 1.1.0 schema."""
         if (
             contents.get('repeatingMinutes') is not None
@@ -247,7 +247,7 @@ class AppSpecYml:
             contents['organization']['repeatingMinutes'] = contents.pop('repeatingMinutes', [])
 
     @staticmethod
-    def _migrate_schema_100_to_110_organization_publish_out_files(contents: dict) -> None:
+    def _migrate_schema_100_to_110_organization_publish_out_files(contents: dict):
         """Migrate 1.0.0 schema to 1.1.0 schema."""
         if (
             contents.get('publishOutFiles') is not None
@@ -257,7 +257,7 @@ class AppSpecYml:
             contents['organization']['publishOutFiles'] = contents.pop('publishOutFiles', [])
 
     @staticmethod
-    def _migrate_schema_100_to_110_input_groups(contents: dict) -> None:
+    def _migrate_schema_100_to_110_input_groups(contents: dict):
         """Migrate 1.0.0 schema to 1.1.0 schema."""
         contents['sections'] = contents.pop('inputGroups', {})
         for section in contents.get('sections'):
@@ -276,7 +276,7 @@ class AppSpecYml:
                     param['type'] = 'String'
 
     @staticmethod
-    def _migrate_schema_100_to_110_notes_per_action(contents: dict) -> None:
+    def _migrate_schema_100_to_110_notes_per_action(contents: dict):
         """Migrate 1.0.0 schema to 1.1.0 schema."""
         contents['notePerAction'] = contents.pop('notes', {})
         note_per_action = []
@@ -285,14 +285,14 @@ class AppSpecYml:
         contents['notePerAction'] = note_per_action
 
     @staticmethod
-    def _migrate_schema_100_to_110_retry(contents: dict) -> None:
+    def _migrate_schema_100_to_110_retry(contents: dict):
         """Migrate 1.0.0 schema to 1.1.0 schema."""
         if contents['runtimeLevel'].lower() == 'playbook':
             contents.setdefault('playbook', {})
             contents['playbook']['retry'] = contents.pop('retry', {})
 
     @staticmethod
-    def _migrate_schema_100_to_110_output_groups(contents: dict) -> None:
+    def _migrate_schema_100_to_110_output_groups(contents: dict):
         """Migrate 1.0.0 schema to 1.1.0 schema."""
         outputs = []
         contents['outputData'] = contents.pop('outputGroups', {})
@@ -324,7 +324,7 @@ class AppSpecYml:
         contents['outputData'] = outputs
 
     @staticmethod
-    def _migrate_schema_100_to_110_jira_notes(contents: dict) -> None:
+    def _migrate_schema_100_to_110_jira_notes(contents: dict):
         """Migrate 1.0.0 schema to 1.1.0 schema."""
         jira_notes = []
         for k, v in contents.get('jira', {}).items():
@@ -335,7 +335,7 @@ class AppSpecYml:
         contents['internalNotes'] = jira_notes
 
     @staticmethod
-    def _migrate_schema_100_to_110_release_notes(contents: dict) -> None:
+    def _migrate_schema_100_to_110_release_notes(contents: dict):
         """Migrate 1.0.0 schema to 1.1.0 schema."""
         release_notes = []
         for k, v in contents.get('releaseNotes').items():
@@ -495,7 +495,7 @@ class AppSpecYml:
 
         return contents
 
-    def write(self, contents: dict) -> None:
+    def write(self, contents: dict):
         """Write yaml to file."""
         with self.fqfn.open(mode='w', encoding='utf-8') as fh:
             fh.write(self.dict_to_yaml(self.order_data(contents)))

--- a/tcex/app_config/install_json.py
+++ b/tcex/app_config/install_json.py
@@ -33,7 +33,7 @@ class InstallJson:
         filename: Optional[str] = None,
         path: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-    ) -> None:
+    ):
         """Initialize class properties."""
         filename = filename or 'install.json'
         path = path or os.getcwd()
@@ -154,7 +154,7 @@ class InstallJson:
 
     # @cached_property
     @property
-    def model(self) -> InstallJsonModel:
+    def model(self) -> 'InstallJsonModel':
         """Return the Install JSON model."""
         return InstallJsonModel(**self.contents)
 
@@ -237,16 +237,16 @@ class InstallJson:
         return ','.join(self.tc_playbook_out_variables)
 
     @property
-    def update(self) -> InstallJsonUpdate:
+    def update(self) -> 'InstallJsonUpdate':
         """Return InstallJsonUpdate instance."""
         return InstallJsonUpdate(ij=self)
 
     @property
-    def validate(self) -> InstallJsonValidate:
+    def validate(self) -> 'InstallJsonValidate':
         """Validate install.json."""
         return InstallJsonValidate(ij=self)
 
-    def write(self) -> None:
+    def write(self):
         """Write current data file."""
         data = self.model.json(
             by_alias=True, exclude_defaults=True, exclude_none=True, indent=2, sort_keys=True

--- a/tcex/app_config/install_json_update.py
+++ b/tcex/app_config/install_json_update.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class InstallJsonUpdate:
     """Update install.json file with current standards and schema."""
 
-    def __init__(self, ij: 'InstallJson') -> None:  # pylint: disable=E0601
+    def __init__(self, ij: 'InstallJson'):  # pylint: disable=E0601
         """Initialize class properties."""
         self.ij = ij
 
@@ -22,7 +22,7 @@ class InstallJsonUpdate:
         sequence: Optional[bool] = True,
         valid_values: Optional[bool] = True,
         playbook_data_types: Optional[bool] = True,
-    ) -> None:
+    ):
         """Update the profile with all required changes.
 
         Args:
@@ -55,7 +55,7 @@ class InstallJsonUpdate:
         # write updated profile
         self.ij.write()
 
-    # def update_display_name(self, json_data: dict) -> None:
+    # def update_display_name(self, json_data: dict):
     #     """Update the displayName parameter."""
     #     if not self.ij.model.display_name:
     #         display_name = os.path.basename(os.getcwd()).replace(self.app_prefix, '')
@@ -63,7 +63,7 @@ class InstallJsonUpdate:
     #         display_name = ' '.join([a.title() for a in display_name.split(' ')])
     #     self.ij.model.display_name = self.ij.model.display_name or display_name
 
-    def update_features(self) -> None:
+    def update_features(self):
         """Update feature set based on App type."""
         features = ['runtimeVariables']
 
@@ -113,16 +113,16 @@ class InstallJsonUpdate:
 
         self.ij.model.features = sorted(list(set(features)))
 
-    def update_program_main(self) -> None:
+    def update_program_main(self):
         """Update program main."""
         self.ij.model.program_main = 'run'
 
-    def update_sequence_numbers(self) -> None:
+    def update_sequence_numbers(self):
         """Update program sequence numbers."""
         for sequence, param in enumerate(self.ij.model.params, start=1):
             param.sequence = sequence
 
-    def update_valid_values(self) -> None:
+    def update_valid_values(self):
         """Update program main on App type."""
         for param in self.ij.model.params:
             if param.type not in ['String', 'KeyValueList']:
@@ -158,7 +158,7 @@ class InstallJsonUpdate:
                 if f'${{ORGANIZATION:{store}}}' in param.valid_values:
                     param.valid_values.remove(f'${{ORGANIZATION:{store}}}')
 
-    def update_playbook_data_types(self) -> None:
+    def update_playbook_data_types(self):
         """Update program main on App type."""
         if self.ij.model.runtime_level.lower() != 'playbook':
             return

--- a/tcex/app_config/install_json_validate.py
+++ b/tcex/app_config/install_json_validate.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class InstallJsonValidate:
     """Validate install.json file."""
 
-    def __init__(self, ij: 'InstallJson') -> None:  # pylint: disable=E0601
+    def __init__(self, ij: 'InstallJson'):  # pylint: disable=E0601
         """Initialize class properties."""
         self.ij = ij
 

--- a/tcex/app_config/job_json.py
+++ b/tcex/app_config/job_json.py
@@ -52,12 +52,12 @@ class JobJson(metaclass=Singleton):
         return _contents
 
     @cached_property
-    def model(self) -> JobJsonModel:
+    def model(self) -> 'JobJsonModel':
         """Return the Install JSON model."""
         return JobJsonModel(**self.contents)
 
     # TODO: [low] possibly add auto fix of version and program name and then uncomment this code.
-    # def write(self) -> None:
+    # def write(self):
     #     """Write current data file."""
     #     data = self.model.json(
     #         by_alias=True, exclude_defaults=True, exclude_none=True, indent=2, sort_keys=True

--- a/tcex/app_config/layout_json.py
+++ b/tcex/app_config/layout_json.py
@@ -28,7 +28,7 @@ class LayoutJson(metaclass=Singleton):
         filename: Optional[str] = None,
         path: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-    ) -> None:
+    ):
         """Initialize class properties."""
         filename = filename or 'layout.json'
         path = path or os.getcwd()
@@ -97,7 +97,7 @@ class LayoutJson(metaclass=Singleton):
         return self.fqfn.is_file()
 
     @cached_property
-    def model(self) -> LayoutJsonModel:
+    def model(self) -> 'LayoutJsonModel':
         """Return the Install JSON model."""
         return LayoutJsonModel(**self.contents)
 
@@ -106,7 +106,7 @@ class LayoutJson(metaclass=Singleton):
         """Return InstallJsonUpdate instance."""
         return LayoutJsonUpdate(lj=self)
 
-    def write(self, data: str) -> None:
+    def write(self, data: str):
         """Write updated file.
 
         Args:
@@ -119,11 +119,11 @@ class LayoutJson(metaclass=Singleton):
 class LayoutJsonUpdate:
     """Update layout.json file with current standards and schema."""
 
-    def __init__(self, lj: LayoutJson) -> None:
+    def __init__(self, lj: LayoutJson):
         """Initialize class properties."""
         self.lj = lj
 
-    def multiple(self) -> None:
+    def multiple(self):
         """Update the layouts.json file."""
         # APP-86 - sort output data by name
         self.update_sort_outputs()
@@ -133,7 +133,7 @@ class LayoutJsonUpdate:
         )
         self.lj.write(data)
 
-    def update_sort_outputs(self) -> None:
+    def update_sort_outputs(self):
         """Sort output field by name."""
         # APP-86 - sort output data by name
         self.lj.model.outputs = sorted(

--- a/tcex/app_config/permutation.py
+++ b/tcex/app_config/permutation.py
@@ -36,7 +36,7 @@ tcex_logger = logging.getLogger('tcex')
 class Permutation:
     """Permutations Module"""
 
-    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+    def __init__(self, logger: Optional[logging.Logger] = None):
         """Initialize Class properties"""
         self.log = logger or tcex_logger
 
@@ -49,7 +49,7 @@ class Permutation:
         self.ij = InstallJson(logger=self.log)
         self.lj = LayoutJson(logger=self.log)
 
-    def _gen_permutations(self, index: Optional[int] = 0, params: Optional[list] = None) -> None:
+    def _gen_permutations(self, index: Optional[int] = 0, params: Optional[list] = None):
         """Iterate recursively over layout.json parameter names to build permutations.
 
         .. NOTE:: Permutations are for layout.json based Apps.
@@ -139,7 +139,7 @@ class Permutation:
             yield ij_data
 
     @cached_property
-    def db_conn(self) -> sqlite3.Connection:
+    def db_conn(self) -> 'sqlite3.Connection':
         """Create a temporary in memory DB and return the connection."""
         try:
             return sqlite3.connect(':memory:')
@@ -148,7 +148,7 @@ class Permutation:
 
         return None
 
-    def db_create_table(self, table_name: str, columns: List[str]) -> None:
+    def db_create_table(self, table_name: str, columns: List[str]):
         """Create a temporary DB table.
 
         Args:
@@ -164,7 +164,7 @@ class Permutation:
         except sqlite3.Error as e:  # pragma: no cover
             self.handle_error(f'SQL create db failed - SQL: "{sql}", Error: "{e}"')
 
-    def db_drop_table(self, table_name: str) -> None:
+    def db_drop_table(self, table_name: str):
         """Drop a DB table.
 
         Args:
@@ -177,7 +177,7 @@ class Permutation:
         except sqlite3.Error as e:  # pragma: no cover
             self.handle_error(f'SQL drop db failed - SQL: "{sql}", Error: "{e}"')
 
-    def db_insert_record(self, table_name: str, columns: List[str]) -> None:
+    def db_insert_record(self, table_name: str, columns: List[str]):
         """Insert records into DB.
 
         A single row will all values as None so that values can be updated one at a
@@ -199,7 +199,7 @@ class Permutation:
         except sqlite3.OperationalError as ex:  # pragma: no cover
             self.handle_error(f'SQL insert failed - SQL: "{sql}", Error: "{ex}"')
 
-    def db_update_record(self, table_name: str, column: str, value: str) -> None:
+    def db_update_record(self, table_name: str, column: str, value: str):
         """Update a single column in the row-column create in db_insert_record.
 
         Args:
@@ -240,7 +240,7 @@ class Permutation:
                 return _tc_action_clause.group(1)
         return None
 
-    def handle_error(self, err: str, halt: Optional[bool] = True) -> None:  # pragma: no cover
+    def handle_error(self, err: str, halt: Optional[bool] = True):  # pragma: no cover
         """Print errors message and optionally exit.
 
         Args:
@@ -253,7 +253,7 @@ class Permutation:
             sys.exit(1)
 
     # TODO: [low] improve this logic
-    def init_permutations(self) -> None:
+    def init_permutations(self):
         """Process layout.json names/display to get all permutations of args."""
         if self._input_permutations is None and self._output_permutations is None:
             self._input_permutations = []
@@ -385,7 +385,7 @@ class Permutation:
 
         # return outputs
 
-    def permutations(self) -> None:
+    def permutations(self):
         """Process layout.json names/display to get all permutations of args."""
         if not self.lj.has_layout:  # pragma: no cover
             print('Only Apps with a layout.json are supported.')
@@ -479,7 +479,7 @@ class Permutation:
                 sys.exit(1)
         return display
 
-    def write_permutations_file(self) -> None:
+    def write_permutations_file(self):
         """Print all valid permutations."""
         permutations = []
         for index, p in enumerate(self.input_permutations):

--- a/tcex/app_config/tcex_json.py
+++ b/tcex/app_config/tcex_json.py
@@ -28,7 +28,7 @@ class TcexJson:
         filename: Optional[str] = None,
         path: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-    ) -> None:
+    ):
         """Initialize class properties."""
         filename = filename or 'tcex.json'
         path = path or os.getcwd()
@@ -57,7 +57,7 @@ class TcexJson:
         return _contents
 
     @cached_property
-    def model(self) -> TcexJsonModel:
+    def model(self) -> 'TcexJsonModel':
         """Return the Install JSON model."""
         return TcexJsonModel(**self.contents)
 
@@ -79,11 +79,11 @@ class TcexJson:
             )
 
     @property
-    def update(self) -> TcexJsonUpdate:
+    def update(self) -> 'TcexJsonUpdate':
         """Return InstallJsonUpdate instance."""
         return TcexJsonUpdate(tj=self)
 
-    def write(self) -> None:
+    def write(self):
         """Write current data file."""
         data = self.model.json(exclude_defaults=True, exclude_none=True, indent=2, sort_keys=True)
         with self.fqfn.open(mode='w') as fh:

--- a/tcex/app_config/tcex_json_update.py
+++ b/tcex/app_config/tcex_json_update.py
@@ -10,11 +10,11 @@ if TYPE_CHECKING:  # pragma: no cover
 class TcexJsonUpdate:
     """Update install.json file with current standards and schema."""
 
-    def __init__(self, tj: 'TcexJson') -> None:  # pylint: disable=E0601
+    def __init__(self, tj: 'TcexJson'):  # pylint: disable=E0601
         """Initialize class properties."""
         self.tj = tj
 
-    def multiple(self, template: Optional[str] = None) -> None:
+    def multiple(self, template: Optional[str] = None):
         """Update the contents of the tcex.json file."""
 
         # update app_name
@@ -36,7 +36,7 @@ class TcexJsonUpdate:
         # write updated profile
         self.tj.write()
 
-    def update_package_app_name(self) -> None:
+    def update_package_app_name(self):
         """Update the package app_name in the tcex.json file."""
         if (
             self.tj.model.package.app_name is None
@@ -59,13 +59,13 @@ class TcexJsonUpdate:
             # update App name
             self.tj.model.package.app_name = _app_name
 
-    # def update_deprecated_fields(self) -> None:
+    # def update_deprecated_fields(self):
     #     """Update deprecated fields in the tcex.json file."""
     #     deprecated_fields = ['profile_include_dirs']
     #     for d in deprecated_fields:
     #         setattr(self.tj.model, d, None)
 
-    def update_package_excludes(self) -> None:
+    def update_package_excludes(self):
         """Update the excludes values in the tcex.json file."""
         for i in [
             '.gitignore',
@@ -79,7 +79,7 @@ class TcexJsonUpdate:
                 # TODO: [low] pydantic doesn't seem to allow removing items from list???
                 self.tj.model.package.excludes.append(i)
 
-    def update_lib_versions(self) -> None:
+    def update_lib_versions(self):
         """Update the lib_versions array in the tcex.json file."""
         if os.getenv('TCEX_LIB_VERSIONS') and not self.tj.model.lib_versions:
             _lib_versions = []

--- a/tcex/app_feature/advanced_request.py
+++ b/tcex/app_feature/advanced_request.py
@@ -34,7 +34,7 @@ class AdvancedRequest:
         session: requests.Session,
         output_prefix: str,
         timeout: Optional[int] = 600,
-    ) -> None:
+    ):
         """Initialize class properties."""
         self.inputs = inputs
         self.output_prefix: str = output_prefix
@@ -51,7 +51,7 @@ class AdvancedRequest:
         self.mt: callable = MimeTypes()
         self.params: dict = {}
 
-    def configure_body(self) -> None:
+    def configure_body(self):
         """Configure Body"""
         self.data: Union[bytes, str] = self.inputs.model.tc_adv_req_body
         if self.data is not None:
@@ -67,7 +67,7 @@ class AdvancedRequest:
             except ValueError:  # pragma: no cover
                 self.log.error('Failed loading body as JSON data.')
 
-    def configure_headers(self) -> None:
+    def configure_headers(self):
         """Configure Headers
 
         [{
@@ -79,7 +79,7 @@ class AdvancedRequest:
             value: str = self.playbook.read.variable(header_data.get('value'))
             self.headers[str(header_data.get('key'))] = str(value)
 
-    def configure_params(self) -> None:
+    def configure_params(self):
         """Configure Params
 
         [{
@@ -101,7 +101,7 @@ class AdvancedRequest:
                 else:
                     self.params.setdefault(param, []).append(str(value))
 
-    def request(self) -> None:
+    def request(self):
         """Make the HTTP request."""
         # configure body
         self.configure_body()

--- a/tcex/bin/bin_abc.py
+++ b/tcex/bin/bin_abc.py
@@ -27,7 +27,7 @@ from tcex.utils.utils import Utils
 class BinABC(ABC):
     """Base Class for ThreatConnect command line tools."""
 
-    def __init__(self) -> None:
+    def __init__(self):
         """Initialize Class properties."""
         # properties
         self.app_path = os.getcwd()
@@ -41,14 +41,14 @@ class BinABC(ABC):
         self.utils = Utils()
 
     @cached_property
-    def cli_out_path(self) -> Path:  # pylint: disable=no-self-use
+    def cli_out_path(self) -> 'Path':  # pylint: disable=no-self-use
         """Return the path to the tcex cli command out directory."""
         _out_path = Path(os.path.expanduser('~/.tcex'))
         _out_path.mkdir(exist_ok=True, parents=True)
         return _out_path
 
     @staticmethod
-    def handle_error(err, halt: Optional[bool] = True) -> None:
+    def handle_error(err, halt: Optional[bool] = True):
         """Print errors message and optionally exit.
 
         Args:
@@ -60,7 +60,7 @@ class BinABC(ABC):
             sys.exit(1)
 
     @cached_property
-    def log(self) -> logging.Logger:
+    def log(self) -> 'logging.Logger':
         """Return the configured logger."""
         # create logger based on custom TestLogger
         logging.setLoggerClass(TraceLogger)
@@ -103,7 +103,7 @@ class BinABC(ABC):
         return logger
 
     @staticmethod
-    def print_block(text: str, max_length: Optional[int] = 80, **kwargs) -> None:
+    def print_block(text: str, max_length: Optional[int] = 80, **kwargs):
         """Print Divider."""
         bold = kwargs.get('bold', False)
         fg_color = getattr(typer.colors, kwargs.get('fg_color', 'white').upper())
@@ -119,7 +119,7 @@ class BinABC(ABC):
         typer.secho(text_wrapped, fg=fg_color, bold=bold)
 
     @staticmethod
-    def print_divider(char: Optional[str] = '-', count: Optional[int] = 100, **kwargs) -> None:
+    def print_divider(char: Optional[str] = '-', count: Optional[int] = 100, **kwargs):
         """Print Divider."""
         bold = kwargs.get('bold', False)
         fg_color = getattr(typer.colors, kwargs.get('fg_color', 'bright_white').upper())
@@ -128,14 +128,14 @@ class BinABC(ABC):
         typer.secho(char * count, fg=fg_color, bold=bold)
 
     @staticmethod
-    def print_failure(message: str, exit_: Optional[bool] = True) -> None:
+    def print_failure(message: str, exit_: Optional[bool] = True):
         """Print Failure."""
         typer.secho(message, fg=typer.colors.RED, bold=True)
         if exit_ is True:
             sys.exit(1)
 
     @staticmethod
-    def print_setting(label: str, value: str, **kwargs) -> None:
+    def print_setting(label: str, value: str, **kwargs):
         """Print Setting."""
         bold = kwargs.get('bold', True)
         fg_color = getattr(typer.colors, kwargs.get('fg_color', 'magenta').upper())
@@ -146,7 +146,7 @@ class BinABC(ABC):
         typer.echo(f'{indent}{label:<20}: {value_display}')
 
     @staticmethod
-    def print_title(title: str, divider: Optional[bool] = True, **kwargs) -> None:
+    def print_title(title: str, divider: Optional[bool] = True, **kwargs):
         """Print Title."""
         bold = kwargs.get('bold', True)
         fg_color = getattr(typer.colors, kwargs.get('fg_color', 'cyan').upper())
@@ -172,7 +172,7 @@ class BinABC(ABC):
         )
 
     @staticmethod
-    def update_system_path() -> None:
+    def update_system_path():
         """Update the system path to ensure project modules and dependencies can be found."""
         cwd = os.getcwd()
         lib_dir = os.path.join(os.getcwd(), 'lib_')

--- a/tcex/bin/dep.py
+++ b/tcex/bin/dep.py
@@ -32,7 +32,7 @@ class Dep(BinABC):
         proxy_port: int,
         proxy_user: str,
         proxy_pass: str,
-    ) -> None:
+    ):
         """Initialize Class properties."""
         super().__init__()
         self.branch = branch
@@ -96,7 +96,7 @@ class Dep(BinABC):
 
         return exe_command
 
-    def _create_lib_latest(self) -> None:
+    def _create_lib_latest(self):
         """Create the lib_latest symlink for App Builder."""
         if platform.system() == 'Windows':
             shutil.copytree(f'lib_{self.latest_version}', self.static_lib_dir)
@@ -108,12 +108,12 @@ class Dep(BinABC):
             os.symlink(f'lib_{self.latest_version}', self.static_lib_dir)
 
     @staticmethod
-    def _remove_previous(fqpn: Path) -> None:
+    def _remove_previous(fqpn: Path):
         """Remove previous lib directory recursively."""
         if os.access(fqpn, os.W_OK):
             shutil.rmtree(fqpn)
 
-    def configure_proxy(self) -> None:
+    def configure_proxy(self):
         """Configure proxy settings using environment variables."""
         if os.getenv('HTTP_PROXY') or os.getenv('HTTPS_PROXY'):
             # don't change proxy settings if the OS already has them configured.
@@ -141,7 +141,7 @@ class Dep(BinABC):
             # display proxy setting
             self.print_setting('Using Proxy Server', f'{self.proxy_host}:{self.proxy_port}')
 
-    def create_temp_requirements(self) -> None:
+    def create_temp_requirements(self):
         """Create a temporary requirements.txt.
 
         This allows testing again a git branch instead of pulling from pypi.
@@ -167,7 +167,7 @@ class Dep(BinABC):
         # display branch setting
         self.print_setting('Using Branch', self.branch)
 
-    def install_deps(self) -> None:
+    def install_deps(self):
         """Install Required Libraries using pip."""
         # check for requirements.txt
         if not self.requirements_fqfn.is_file():

--- a/tcex/bin/deploy.py
+++ b/tcex/bin/deploy.py
@@ -29,7 +29,7 @@ class Deploy(BinABC):
         proxy_port: int,
         proxy_user: str,
         proxy_pass: str,
-    ) -> None:
+    ):
         """Initialize Class properties."""
         super().__init__()
         self._app_file = app_file
@@ -42,7 +42,7 @@ class Deploy(BinABC):
         self.server = server
 
     @staticmethod
-    def _handle_missing_environment(variable: str) -> None:
+    def _handle_missing_environment(variable: str):
         """Print error on missing environment variable."""
         typer.secho(
             f'Could not find environment variable: {variable}.',

--- a/tcex/bin/package.py
+++ b/tcex/bin/package.py
@@ -24,9 +24,7 @@ class Package(BinABC):
     install.json file or files will be automatically run before packaging the app.
     """
 
-    def __init__(
-        self, excludes: Optional[List[str]], ignore_validation: bool, output_dir: Path
-    ) -> None:
+    def __init__(self, excludes: Optional[List[str]], ignore_validation: bool, output_dir: Path):
         """Initialize Class properties."""
         super().__init__()
         self._excludes = excludes or []
@@ -99,14 +97,14 @@ class Package(BinABC):
         return excluded_files
 
     @cached_property
-    def build_fqpn(self) -> Path:
+    def build_fqpn(self) -> 'Path':
         """Return the fully qualified path name of the build directory."""
         build_fqpn = Path(os.path.join(self.app_path, self.output_dir.name, 'build'))
         build_fqpn.mkdir(exist_ok=True, parents=True)
         return build_fqpn
 
     @cached_property
-    def template_fqpn(self) -> Path:
+    def template_fqpn(self) -> 'Path':
         """Return the fully qualified path name of the template directory."""
         template_fqpn = Path(os.path.join(self.build_fqpn, 'template'))
         if os.access(template_fqpn, os.W_OK):
@@ -119,7 +117,7 @@ class Package(BinABC):
         )
         return template_fqpn
 
-    def package(self) -> None:
+    def package(self):
         """Build the App package for deployment to ThreatConnect Exchange."""
         # copy project directory to temp location to use as template for multiple builds
         shutil.copytree(self.app_path, self.template_fqpn, False, ignore=self.exclude_files)
@@ -158,13 +156,13 @@ class Package(BinABC):
         # cleanup build directory
         shutil.rmtree(app_path_fqpn)
 
-    def print_json(self) -> None:
+    def print_json(self):
         """[App Builder] Print JSON output containing results of the package command."""
         print(
             json.dumps({'package_data': self.package_data, 'validation_data': self.validation_data})
         )
 
-    def print_results(self) -> None:
+    def print_results(self):
         """Print results of the package command."""
         # Updates
         if self.package_data.get('updates'):
@@ -204,7 +202,7 @@ class Package(BinABC):
                 print(f'{c.Fore.RED}{error}')
                 self.exit_code = 1
 
-    def zip_file(self, app_path: Path, app_name: Path, tmp_path: Path) -> None:
+    def zip_file(self, app_path: Path, app_name: Path, tmp_path: Path):
         """Zip the App with tcex extension.
 
         Args:

--- a/tcex/bin/spec_tool.py
+++ b/tcex/bin/spec_tool.py
@@ -25,7 +25,7 @@ from tcex.bin.spec_tool_tcex_json import SpecToolTcexJson
 class SpecTool(BinABC):
     """Generate App Config Files"""
 
-    def __init__(self, overwrite: bool = False) -> None:
+    def __init__(self, overwrite: bool = False):
         """Initialize class properties."""
         super().__init__()
         self.overwrite = overwrite
@@ -106,7 +106,7 @@ class SpecTool(BinABC):
 
         return _code
 
-    def generate_app_input(self) -> None:
+    def generate_app_input(self):
         """Generate the app_input.py file."""
         # force migration of app.yaml file
         _ = self.asy.model.app_id
@@ -126,7 +126,7 @@ class SpecTool(BinABC):
                 )
             self.report_data['Mismatch Report'] = _report
 
-    def generate_app_spec(self, schema: bool) -> None:
+    def generate_app_spec(self, schema: bool):
         """Generate the app_spec.yml file."""
         gen = SpecToolAppSpecYml()
         if schema:
@@ -139,7 +139,7 @@ class SpecTool(BinABC):
 
             self.write_app_file(gen.filename, f'{config}\n')
 
-    def generate_install_json(self, schema: bool) -> None:
+    def generate_install_json(self, schema: bool):
         """Generate the install.json file."""
         gen = SpecToolInstallJson(self.asy)
         if schema:
@@ -163,7 +163,7 @@ class SpecTool(BinABC):
             )
             self.write_app_file(gen.filename, f'{config}\n')
 
-    def generate_layout_json(self, schema: bool) -> None:
+    def generate_layout_json(self, schema: bool):
         """Generate the layout.json file."""
         gen = SpecToolLayoutJson(self.asy)
         if schema:
@@ -188,7 +188,7 @@ class SpecTool(BinABC):
                 )
                 self.write_app_file(gen.filename, f'{config}\n')
 
-    def generate_job_json(self, schema: bool) -> None:
+    def generate_job_json(self, schema: bool):
         """Generate the job.json file."""
         gen = SpecToolJobJson(self.asy)
         if schema:
@@ -212,7 +212,7 @@ class SpecTool(BinABC):
             except ValidationError as ex:
                 self.print_failure(f'Failed Generating job.json:\n{ex}')
 
-    def generate_readme_md(self) -> None:
+    def generate_readme_md(self):
         """Generate the README.me file."""
         # check that app_spec.yml exists
         self._check_has_spec()
@@ -221,7 +221,7 @@ class SpecTool(BinABC):
         readme_md = gen.generate()
         self.write_app_file(gen.filename, '\n'.join(readme_md))
 
-    def generate_tcex_json(self, schema: bool) -> None:
+    def generate_tcex_json(self, schema: bool):
         """Generate the tcex.json file."""
         gen = SpecToolTcexJson(self.asy)
         if schema:
@@ -245,7 +245,7 @@ class SpecTool(BinABC):
             )
             self.write_app_file(gen.filename, f'{config}\n')
 
-    def rename_app_file(self, src_filename: str, dest_filename: str) -> None:
+    def rename_app_file(self, src_filename: str, dest_filename: str):
         """Rename the app.yaml file to app_spec.yml."""
         if os.path.isfile(src_filename):
             self.log.debug(

--- a/tcex/bin/spec_tool.py
+++ b/tcex/bin/spec_tool.py
@@ -153,9 +153,12 @@ class SpecTool(BinABC):
             except ValidationError as ex:
                 self.print_failure(f'Failed Generating install.json:\n{ex}')
 
+            # exclude_defaults - if False then all unused fields are added in - not good.
+            # exclude_none - this should be safe to leave as True.
+            # exclude_unset - this should be safe to leave as True.
             config = ij.json(
                 by_alias=True,
-                exclude_defaults=False,
+                exclude_defaults=True,
                 exclude_none=True,
                 exclude_unset=True,
                 indent=2,
@@ -178,9 +181,12 @@ class SpecTool(BinABC):
                 except ValidationError as ex:
                     self.print_failure(f'Failed Generating layout.json:\n{ex}')
 
+                # exclude_defaults - if False then all unused fields are added in - not good.
+                # exclude_none - this should be safe to leave as True.
+                # exclude_unset - this should be safe to leave as True.
                 config = lj.json(
                     by_alias=True,
-                    exclude_defaults=False,
+                    exclude_defaults=True,
                     exclude_none=True,
                     exclude_unset=True,
                     indent=2,
@@ -202,7 +208,7 @@ class SpecTool(BinABC):
                     if job is not None:
                         config = job.json(
                             by_alias=True,
-                            exclude_defaults=False,
+                            exclude_defaults=True,
                             exclude_none=True,
                             exclude_unset=True,
                             indent=2,
@@ -235,9 +241,12 @@ class SpecTool(BinABC):
             except ValidationError as ex:
                 self.print_failure(f'Failed Generating tcex.json:\n{ex}')
 
+            # exclude_defaults - if False then all unused fields are added in - not good.
+            # exclude_none - this should be safe to leave as True.
+            # exclude_unset - this should be safe to leave as True.
             config = tj.json(
                 by_alias=True,
-                exclude_defaults=False,
+                exclude_defaults=True,
                 exclude_none=True,
                 exclude_unset=True,
                 indent=2,

--- a/tcex/bin/spec_tool_app_input.py
+++ b/tcex/bin/spec_tool_app_input.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 class SpecToolAppInput(BinABC):
     """Generate App Config File"""
 
-    def __init__(self) -> None:
+    def __init__(self):
         """Initialize class properties."""
         super().__init__()
 
@@ -35,7 +35,7 @@ class SpecToolAppInput(BinABC):
         self.permutations = Permutation(self.log)
         self.report_mismatch = []
 
-    def _add_action_classes(self) -> None:
+    def _add_action_classes(self):
         """Add actions to the App."""
         for action in self._tc_actions:
             class_name = self._gen_tc_action_class_name(action)
@@ -44,14 +44,14 @@ class SpecToolAppInput(BinABC):
 
     def _add_input_to_action_class(
         self, applies_to_all: bool, param_data: 'ParamsModel', tc_action: Optional[str] = None
-    ) -> None:
+    ):
         """Add input data to Action class."""
         tc_action_class = 'AppBaseModel'
         if applies_to_all is False:
             tc_action_class = self._gen_tc_action_class_name(tc_action)
         self.app_inputs_data[tc_action_class][param_data.name] = param_data
 
-    def _add_typing_import_module(self, type_: str) -> None:
+    def _add_typing_import_module(self, type_: str):
         """Add the appropriate import module for typing."""
         if 'List[' in type_:
             self.typing_modules.add('List')
@@ -73,7 +73,7 @@ class SpecToolAppInput(BinABC):
         return _comment_map.get(model_class, _class_comment)
 
     @property
-    def _code_app_inputs_data(self) -> None:
+    def _code_app_inputs_data(self):
         """Return app_inputs.py input data."""
         _code = []
         # sorting of the inputs can only be done at this point
@@ -211,7 +211,7 @@ class SpecToolAppInput(BinABC):
             return type_data
         return type_data
 
-    def _generate_app_inputs_to_action(self) -> None:
+    def _generate_app_inputs_to_action(self):
         """Generate App Input dict from install.json and layout.json."""
         if self.ij.model.runtime_level.lower() in ['triggerservice', 'webhooktriggerservice']:
             for ij_data in self.ij.model.params_dict.values():
@@ -518,7 +518,7 @@ class SpecToolAppInput(BinABC):
             self._add_action_classes()
         return self._app_inputs_data
 
-    def generate(self) -> None:
+    def generate(self):
         """Generate App Config File"""
         self.log.debug('--- generate: AppConfig ---')
 

--- a/tcex/bin/spec_tool_app_input_static.py
+++ b/tcex/bin/spec_tool_app_input_static.py
@@ -9,7 +9,7 @@ from tcex.app_config.install_json import InstallJson
 class SpecToolAppInputStatic:
     """Generate App Config File"""
 
-    def __init__(self) -> None:
+    def __init__(self):
         """Initialize class properties."""
 
         # class properties
@@ -28,11 +28,11 @@ class SpecToolAppInputStatic:
             '''class AppInputs:''',
             f'''{self.i1}"""App Inputs"""''',
             '',
-            f'''{self.i1}def __init__(self, inputs: 'BaseModel') -> None:''',
+            f'''{self.i1}def __init__(self, inputs: 'BaseModel'):''',
             f'''{self.i2}"""Initialize class properties."""''',
             f'''{self.i2}self.inputs = inputs''',
             '',
-            f'''{self.i1}def update_inputs(self) -> None:''',
+            f'''{self.i1}def update_inputs(self):''',
             f'''{self.i2}"""Add custom App models to inputs.''',
             '',
             f'''{self.i2}Input will be validate when the model is added an any exceptions will''',
@@ -94,7 +94,7 @@ class SpecToolAppInputStatic:
             '''class AppInputs:''',
             f'''{self.i1}"""App Inputs"""''',
             '',
-            f'''{self.i1}def __init__(self, inputs: 'BaseModel') -> None:''',
+            f'''{self.i1}def __init__(self, inputs: 'BaseModel'):''',
             f'''{self.i2}"""Initialize class properties."""''',
             f'''{self.i2}self.inputs = inputs''',
             '',
@@ -104,7 +104,7 @@ class SpecToolAppInputStatic:
             f'''{self.i2}action_model_map = {cmm}''',
             f'''{self.i2}return action_model_map.get(tc_action)''',
             '',
-            f'''{self.i1}def update_inputs(self) -> None:''',
+            f'''{self.i1}def update_inputs(self):''',
             f'''{self.i2}"""Add custom App models to inputs.''',
             '',
             f'''{self.i2}Input will be validate when the model is added an any exceptions will''',

--- a/tcex/bin/spec_tool_app_spec_yml.py
+++ b/tcex/bin/spec_tool_app_spec_yml.py
@@ -61,7 +61,7 @@ class SpecToolAppSpecYml(BinABC):
             return
 
         feeds = []
-        for feed in self.ij.model.feeds:
+        for feed in self.ij.model.feeds or []:
             if not os.path.isfile(feed.job_file):
                 self.log.error(
                     f'feature=app-spec-yml, exception=failed-reading-file, filename={feed.job_file}'

--- a/tcex/bin/spec_tool_app_spec_yml.py
+++ b/tcex/bin/spec_tool_app_spec_yml.py
@@ -15,7 +15,7 @@ from tcex.bin.bin_abc import BinABC
 class SpecToolAppSpecYml(BinABC):
     """Generate App Config File"""
 
-    def __init__(self) -> None:
+    def __init__(self):
         """Initialize class properties."""
         super().__init__()
 
@@ -26,7 +26,7 @@ class SpecToolAppSpecYml(BinABC):
         self.jj = JobJson(logger=self.log)
         self.lj = LayoutJson(logger=self.log)
 
-    def _add_standard_fields(self, app_spec_yml_data: dict) -> None:
+    def _add_standard_fields(self, app_spec_yml_data: dict):
         """Add field that apply to ALL App types."""
         app_spec_yml_data.update(
             {
@@ -48,14 +48,14 @@ class SpecToolAppSpecYml(BinABC):
             }
         )
 
-    def _add_category(self, app_spec_yml_data: dict) -> None:
+    def _add_category(self, app_spec_yml_data: dict):
         """Add category."""
         _category = ''
         if self.ij.model.runtime_level.lower() != 'organization':
             _category = self.ij.model.playbook.type or ''
         app_spec_yml_data['category'] = _category
 
-    def _add_feeds(self, app_spec_yml_data: dict) -> None:
+    def _add_feeds(self, app_spec_yml_data: dict):
         """Add organization feeds section."""
         if self.ij.model.runtime_level.lower() != 'organization':
             return
@@ -75,7 +75,7 @@ class SpecToolAppSpecYml(BinABC):
         app_spec_yml_data.setdefault('organization', {})
         app_spec_yml_data['organization']['feeds'] = feeds
 
-    def _add_note_per_action(self, app_spec_yml_data: dict) -> None:
+    def _add_note_per_action(self, app_spec_yml_data: dict):
         """Add note per action."""
         _notes_per_action = []
         param = self.ij.model.get_param('tc_action')
@@ -85,7 +85,7 @@ class SpecToolAppSpecYml(BinABC):
 
             app_spec_yml_data['notesPerAction'] = _notes_per_action
 
-    def _add_organization(self, app_spec_yml_data: dict) -> None:
+    def _add_organization(self, app_spec_yml_data: dict):
         """Add asy.organization."""
         if self.ij.model.runtime_level.lower() == 'organization':
             app_spec_yml_data.setdefault('organization', {})
@@ -98,7 +98,7 @@ class SpecToolAppSpecYml(BinABC):
                     'repeatingMinutes'
                 ] = self.ij.model.repeating_minutes
 
-    def _add_output_data(self, app_spec_yml_data: dict) -> None:
+    def _add_output_data(self, app_spec_yml_data: dict):
         """Add asy.outputData."""
         if self.ij.model.runtime_level.lower() != 'organization':
             # build outputs based on display value
@@ -122,7 +122,7 @@ class SpecToolAppSpecYml(BinABC):
 
             app_spec_yml_data['outputData'] = _output_data
 
-    def _add_playbook(self, app_spec_yml_data: dict) -> None:
+    def _add_playbook(self, app_spec_yml_data: dict):
         """Add asy.playbook."""
         if self.ij.model.runtime_level.lower() != 'organization':
             app_spec_yml_data.setdefault('playbook', {})
@@ -130,7 +130,7 @@ class SpecToolAppSpecYml(BinABC):
                 app_spec_yml_data['playbook']['retry'] = self.ij.model.playbook.retry
 
     @staticmethod
-    def _add_release_notes(app_spec_yml_data: dict) -> None:
+    def _add_release_notes(app_spec_yml_data: dict):
         """Add release_notes."""
         app_spec_yml_data['releaseNotes'] = [
             {
@@ -139,7 +139,7 @@ class SpecToolAppSpecYml(BinABC):
             }
         ]
 
-    def _add_sections(self, app_spec_yml_data: dict) -> None:
+    def _add_sections(self, app_spec_yml_data: dict):
         """Return params from ij and lj formatted for app_spec."""
         sections = []
         for section in self._current_data:
@@ -178,13 +178,13 @@ class SpecToolAppSpecYml(BinABC):
                     return True
         return False
 
-    def _add_min_tc_version(self, app_spec_yml_data: dict) -> None:
+    def _add_min_tc_version(self, app_spec_yml_data: dict):
         """Add the correct min TC server version."""
 
         if self._is_64_min_version() and self.ij.model.min_server_version < Version('6.4.0'):
             app_spec_yml_data['minServerVersion'] = '6.4.0'
 
-    def generate(self) -> None:
+    def generate(self):
         """Generate the layout.json file data."""
         app_spec_yml_data = {}
 

--- a/tcex/bin/spec_tool_install_json.py
+++ b/tcex/bin/spec_tool_install_json.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class SpecToolInstallJson(BinABC):
     """Generate App Config File"""
 
-    def __init__(self, asy: 'AppSpecYml') -> None:
+    def __init__(self, asy: 'AppSpecYml'):
         """Initialize class properties."""
         super().__init__()
         self.asy = asy
@@ -22,7 +22,7 @@ class SpecToolInstallJson(BinABC):
         # properties
         self.filename = 'install.json'
 
-    def _add_standard_fields(self, install_json_data: dict) -> None:
+    def _add_standard_fields(self, install_json_data: dict):
         """Add field that apply to ALL App types."""
         install_json_data.update(
             {
@@ -46,12 +46,12 @@ class SpecToolInstallJson(BinABC):
             }
         )
 
-    def _add_type_api_service_fields(self, install_json_data: dict) -> None:
+    def _add_type_api_service_fields(self, install_json_data: dict):
         """Add field that apply to ALL App types."""
         if self.asy.model.runtime_level.lower() == 'apiservice':
             install_json_data['displayPath'] = self.asy.model.display_path
 
-    def _add_type_organization_fields(self, install_json_data: dict) -> None:
+    def _add_type_organization_fields(self, install_json_data: dict):
         """Add field that apply to ALL App types."""
         if self.asy.model.organization:
             # the nested job object is not part of the install.json, it
@@ -75,7 +75,7 @@ class SpecToolInstallJson(BinABC):
             if _repeating_minutes:
                 install_json_data['repeatingMinutes'] = _repeating_minutes
 
-    def _add_type_playbook_fields(self, install_json_data: dict) -> None:
+    def _add_type_playbook_fields(self, install_json_data: dict):
         """Add field that apply to ALL App types."""
         if self.asy.model.runtime_level.lower() in [
             'playbook',
@@ -103,7 +103,7 @@ class SpecToolInstallJson(BinABC):
             note_per_action = '\n\n'.join(self.asy.model.note_per_action_formatted)
         return note_per_action
 
-    def generate(self) -> None:
+    def generate(self):
         """Generate the install.json file data."""
         # all keys added to dict must be in camelCase
         install_json_data = {}

--- a/tcex/bin/spec_tool_job_json.py
+++ b/tcex/bin/spec_tool_job_json.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class SpecToolJobJson(BinABC):
     """Generate App Config File"""
 
-    def __init__(self, asy: 'AppSpecYml') -> None:
+    def __init__(self, asy: 'AppSpecYml'):
         """Initialize class properties."""
         super().__init__()
         self.asy = asy
@@ -23,7 +23,7 @@ class SpecToolJobJson(BinABC):
         # properties
         self.tj = TcexJson(logger=self.log)
 
-    def generate(self) -> None:
+    def generate(self):
         """Generate the layout.json file data."""
         if self.asy.model.organization and self.asy.model.organization.feeds:
             for feed in self.asy.model.organization.feeds:

--- a/tcex/bin/spec_tool_layout_json.py
+++ b/tcex/bin/spec_tool_layout_json.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class SpecToolLayoutJson(BinABC):
     """Generate App Config File"""
 
-    def __init__(self, asy: 'AppSpecYml') -> None:
+    def __init__(self, asy: 'AppSpecYml'):
         """Initialize class properties."""
         super().__init__()
         self.asy = asy
@@ -22,7 +22,7 @@ class SpecToolLayoutJson(BinABC):
         # properties
         self.filename = 'layout.json'
 
-    def generate(self) -> None:
+    def generate(self):
         """Generate the layout.json file data."""
 
         layout_json_data = {

--- a/tcex/bin/spec_tool_readme_md.py
+++ b/tcex/bin/spec_tool_readme_md.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class SpecToolReadmeMd(BinABC):
     """Generate App Config File"""
 
-    def __init__(self, asy: 'AppSpecYml') -> None:
+    def __init__(self, asy: 'AppSpecYml'):
         """Initialize class properties."""
         super().__init__()
         self.asy = asy
@@ -27,14 +27,14 @@ class SpecToolReadmeMd(BinABC):
         self.permutations = Permutation(self.log)
 
     @staticmethod
-    def _add_actions_title(readme_md: List[str]) -> None:
+    def _add_actions_title(readme_md: List[str]):
         """Add title for action section."""
         readme_md.append('# Actions')
         readme_md.append('')
         readme_md.append('---')
         readme_md.append('')
 
-    def _add_actions_sub_title(self, readme_md: List[str], action: str) -> None:
+    def _add_actions_sub_title(self, readme_md: List[str], action: str):
         """Add title for sub action section."""
         readme_md.append(f'## {action}')
         npa = self.asy.model.get_note_per_action(action).note
@@ -42,7 +42,7 @@ class SpecToolReadmeMd(BinABC):
             readme_md.append(self.asy.model.get_note_per_action(action).note)
             readme_md.append('')
 
-    def _add_labels(self, readme_md: List[str]) -> None:
+    def _add_labels(self, readme_md: List[str]):
         """Add labels data to readme.md."""
         if self.asy.model.labels:
             readme_md.append('# Labels')
@@ -50,7 +50,7 @@ class SpecToolReadmeMd(BinABC):
             _labels = ', '.join(sorted(self.asy.model.labels))
             readme_md.append(f'- {_labels}')
 
-    def _add_description(self, readme_md: List[str]) -> None:
+    def _add_description(self, readme_md: List[str]):
         """Add top level description/note data to readme.md."""
         if self.asy.model.note:
             readme_md.append('# Description')
@@ -62,20 +62,20 @@ class SpecToolReadmeMd(BinABC):
                 readme_md.append('')
 
     @staticmethod
-    def _add_inputs_title(readme_md: List[str], header: int) -> None:
+    def _add_inputs_title(readme_md: List[str], header: int):
         """Add title for input section."""
         header_value = '#' * header
         readme_md.append(f'{header_value} Inputs')
         readme_md.append('')
 
     @staticmethod
-    def _add_service_config_title(readme_md: List[str], header: int) -> None:
+    def _add_service_config_title(readme_md: List[str], header: int):
         """Add title for service configuration section."""
         header_value = '#' * header
         readme_md.append(f'{header_value} Service Configuration')
         readme_md.append('')
 
-    def _add_param(self, readme_md: List[str], param: 'ParamsModel') -> None:
+    def _add_param(self, readme_md: List[str], param: 'ParamsModel'):
         """Add params data to readme.md.
 
         **API Key** _(String)_
@@ -104,7 +104,7 @@ class SpecToolReadmeMd(BinABC):
 
     def _add_params(
         self, readme_md: List[str], section: 'SectionsModel', action: Optional[str] = None
-    ) -> None:
+    ):
         # add params
         for param in section.params:
             if param.disabled is True or param.hidden is True:
@@ -131,13 +131,13 @@ class SpecToolReadmeMd(BinABC):
             # add param valid_values data
             self._add_param_valid_values(readme_md, param)
 
-    def _add_param_note(self, readme_md: List[str], param: 'ParamsModel') -> None:
+    def _add_param_note(self, readme_md: List[str], param: 'ParamsModel'):
         """Add note data to readme.md."""
         if param.note:
             readme_md.append(f'{self.i1}{param.note}')
             readme_md.append('')
 
-    def _add_param_pb_data_type(self, readme_md: List[str], param: 'ParamsModel') -> None:
+    def _add_param_pb_data_type(self, readme_md: List[str], param: 'ParamsModel'):
         """Add playbook data types values data to readme.md."""
         # matching current format where single 'String' is not displayed
         if param.playbook_data_type and param.playbook_data_type != ['String']:
@@ -145,7 +145,7 @@ class SpecToolReadmeMd(BinABC):
             readme_md.append(f'{self.i1}> **Allows:** {_pdt}')
             readme_md.append('')
 
-    def _add_param_valid_values(self, readme_md: List[str], param: 'ParamsModel') -> None:
+    def _add_param_valid_values(self, readme_md: List[str], param: 'ParamsModel'):
         """Add valid values data to readme.md."""
         # matching current format where TEXT and KEYCHAIN were excluded.
         valid_values = [p for p in param.valid_values if not p.startswith('${')]
@@ -154,7 +154,7 @@ class SpecToolReadmeMd(BinABC):
             readme_md.append(f'{self.i1}> **Valid Values:** {_valid_values}')
             readme_md.append('')
 
-    def _add_outputs(self, readme_md: List[str], action: str = None) -> None:
+    def _add_outputs(self, readme_md: List[str], action: str = None):
         """Add output data to readme.md."""
         if self.asy.model.output_variables:
             readme_md.append('### Outputs')
@@ -189,12 +189,12 @@ class SpecToolReadmeMd(BinABC):
         )
 
     @staticmethod
-    def _add_section_title(readme_md: List[str], section: 'SectionsModel') -> None:
+    def _add_section_title(readme_md: List[str], section: 'SectionsModel'):
         """Add title for input section."""
         readme_md.append(f'### *{section.section_name}*')
         readme_md.append('')
 
-    def _add_params_for_playbook_action_app(self, readme_md: List[str], actions: List[str]) -> None:
+    def _add_params_for_playbook_action_app(self, readme_md: List[str], actions: List[str]):
         """Add inputs for playbook action app."""
         # add title for actions section
         self._add_actions_title(readme_md)
@@ -224,7 +224,7 @@ class SpecToolReadmeMd(BinABC):
             # add horizontal rule
             readme_md.append('---')
 
-    def _add_params_for_playbook_std_app(self, readme_md: List[str]) -> None:
+    def _add_params_for_playbook_std_app(self, readme_md: List[str]):
         """Add inputs for playbook standard app."""
         self._add_inputs_title(readme_md, 3)
 
@@ -246,7 +246,7 @@ class SpecToolReadmeMd(BinABC):
             # add output data
             self._add_outputs(readme_md)
 
-    def _add_params_for_non_playbook_apps(self, readme_md: List[str]) -> None:
+    def _add_params_for_non_playbook_apps(self, readme_md: List[str]):
         """Add inputs for non playbook app."""
         service_config = []
         non_service_config = []

--- a/tcex/bin/spec_tool_tcex_json.py
+++ b/tcex/bin/spec_tool_tcex_json.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class SpecToolTcexJson(BinABC):
     """Generate App Config File"""
 
-    def __init__(self, asy: 'AppSpecYml') -> None:
+    def __init__(self, asy: 'AppSpecYml'):
         """Initialize class properties."""
         super().__init__()
         self.asy = asy
@@ -24,7 +24,7 @@ class SpecToolTcexJson(BinABC):
         self.filename = 'tcex.json'
         self.tj = TcexJson()
 
-    def generate(self) -> None:
+    def generate(self):
         """Generate the layout.json file data."""
 
         tcex_json_data = self.tj.model.dict()

--- a/tcex/bin/template.py
+++ b/tcex/bin/template.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class Template(BinABC):
     """Install dependencies for App."""
 
-    def __init__(self) -> None:
+    def __init__(self):
         """Initialize class properties."""
         super().__init__()
 
@@ -102,14 +102,14 @@ class Template(BinABC):
             yield content
 
     @cached_property
-    def db(self) -> TinyDB:
+    def db(self) -> 'TinyDB':
         """Return db instance."""
         try:
             return TinyDB(os.path.join(self.cli_out_path, 'tcex.json'))
         except Exception:
             return None
 
-    def db_add_config(self, config: TemplateConfigModel) -> None:
+    def db_add_config(self, config: TemplateConfigModel):
         """Add a config to the DB."""
         Config = Query()
         try:
@@ -123,7 +123,7 @@ class Template(BinABC):
             self.log.error(f'Failed inserting config in db ({ex}).')
             self.errors = True
 
-    def db_add_sha(self, sha: str) -> None:
+    def db_add_sha(self, sha: str):
         """Add a config to the DB."""
         SHA = Query()
         try:
@@ -132,7 +132,7 @@ class Template(BinABC):
             self.log.error(f'Failed inserting config in db ({ex}).')
             self.errors = True
 
-    def db_get_config(self, type_: str, template: str) -> TemplateConfigModel:
+    def db_get_config(self, type_: str, template: str) -> 'TemplateConfigModel':
         """Get a config from the DB."""
         Config = Query()
         try:
@@ -148,7 +148,7 @@ class Template(BinABC):
             self.errors = True
             return None
 
-    def db_get_sha(self, sha: str) -> None:
+    def db_get_sha(self, sha: str):
         """Get repo SHA from the DB."""
         SHA = Query()
         try:
@@ -161,7 +161,7 @@ class Template(BinABC):
             self.errors = True
             return None
 
-    def download_template_file(self, item: dict) -> None:
+    def download_template_file(self, item: dict):
         """Download the provided source file to the provided destination."""
         download_url = item.get('download_url')
         name = item.get('name')
@@ -201,7 +201,7 @@ class Template(BinABC):
 
     def get_template_config(
         self, type_: str, template: str, branch: str = 'main'
-    ) -> TemplateConfigModel:
+    ) -> 'TemplateConfigModel':
         """Return the data from the template.yaml file."""
         self.log.info(
             f'action=get-template-config, type={type_}, '
@@ -263,7 +263,7 @@ class Template(BinABC):
 
         return downloads.values()
 
-    def list(self, branch: str, type_: Optional[str] = None) -> None:
+    def list(self, branch: str, type_: Optional[str] = None):
         """List template types."""
         template_types = self.template_types
         if type_ is not None:
@@ -281,7 +281,7 @@ class Template(BinABC):
                         self.template_data.setdefault(selected_type, [])
                         self.template_data[selected_type].append(template_config)
 
-    def print_error_message(self) -> None:
+    def print_error_message(self):
         """Print error message, if applicable."""
         if self.errors is True:
             print(
@@ -289,7 +289,7 @@ class Template(BinABC):
                 f'''see logs at {os.path.join(self.cli_out_path, 'tcex.log')}.'''
             )
 
-    def print_list(self, branch: Optional[str] = None) -> None:
+    def print_list(self, branch: Optional[str] = None):
         """Print the list output."""
         for type_, templates in self.template_data.items():
             self.print_title(f'''{type_.replace('_', ' ').title()} Templates''')
@@ -333,7 +333,7 @@ class Template(BinABC):
         return commits_data[0].get('sha')
 
     @cached_property
-    def session(self) -> Session:
+    def session(self) -> 'Session':
         """Return session object"""
         session = Session()
         session.headers.update({'Cache-Control': 'no-cache'})
@@ -345,14 +345,14 @@ class Template(BinABC):
         return session
 
     @cached_property
-    def template_manifest(self) -> None:
+    def template_manifest(self):
         """Write the template manifest file."""
         if self.template_manifest_fqfn.is_file():
             with self.template_manifest_fqfn.open() as fh:
                 return json.load(fh)
         return {}
 
-    def template_manifest_write(self) -> None:
+    def template_manifest_write(self):
         """Write the template manifest file."""
         with self.template_manifest_fqfn.open(mode='w') as fh:
             fh.write(json.dumps(self.template_manifest, indent=2, sort_keys=True))
@@ -481,7 +481,7 @@ class Template(BinABC):
 
         return downloads
 
-    def update_tcex_json(self) -> None:
+    def update_tcex_json(self):
         """Update the tcex.json file."""
         self.tj.model.template_repo_hash = self.project_sha
         self.tj.write()

--- a/tcex/bin/validate.py
+++ b/tcex/bin/validate.py
@@ -17,10 +17,10 @@ from pydantic import ValidationError
 from stdlib_list import stdlib_list
 
 # first-party
-from tcex.app_config import Permutation
 from tcex.app_config.install_json import InstallJson
 from tcex.app_config.job_json import JobJson
 from tcex.app_config.layout_json import LayoutJson
+from tcex.app_config.permutation import Permutation
 from tcex.app_config.tcex_json import TcexJson
 from tcex.bin.bin_abc import BinABC
 
@@ -41,7 +41,7 @@ class Validate(BinABC):
     * layout.json schema
     """
 
-    def __init__(self, ignore_validation: bool) -> None:
+    def __init__(self, ignore_validation: bool):
         """Initialize Class properties."""
         super().__init__()
         self.permutations = Permutation()
@@ -72,7 +72,7 @@ class Validate(BinABC):
             'feeds': [],
         }
 
-    def _check_node_import(self, node: Union[ast.Import, ast.ImportFrom], filename: str) -> None:
+    def _check_node_import(self, node: Union[ast.Import, ast.ImportFrom], filename: str):
         """."""
         if isinstance(node, ast.Import):
             for n in node.names:
@@ -100,7 +100,7 @@ class Validate(BinABC):
                     {'filename': filename, 'module': m, 'status': m_status}
                 )
 
-    def check_imports(self) -> None:
+    def check_imports(self):
         """Check the projects top level directory for missing imports.
 
         This method will check only files ending in **.py** and does not handle imports validation
@@ -177,7 +177,7 @@ class Validate(BinABC):
                 pass
         return found
 
-    def check_install_json(self) -> None:
+    def check_install_json(self):
         """Check all install.json files for valid schema."""
         if 'install.json' in self.invalid_json_files:
             return
@@ -200,7 +200,7 @@ class Validate(BinABC):
 
         self.validation_data['schema'].append({'filename': self.ij.fqfn.name, 'status': status})
 
-    def check_job_json(self) -> None:
+    def check_job_json(self):
         """Validate feed files for feed job apps."""
         if 'install.json' in self.invalid_json_files:
             # can't proceed if install.json can't be read
@@ -259,7 +259,7 @@ class Validate(BinABC):
 
             self.validation_data['schema'].append({'filename': feed.job_file, 'status': status})
 
-    def check_layout_json(self) -> None:
+    def check_layout_json(self):
         """Check all layout.json files for valid schema."""
         if not self.lj.has_layout or 'layout.json' in self.invalid_json_files:
             return
@@ -285,7 +285,7 @@ class Validate(BinABC):
         if status is True:
             self.check_layout_params()
 
-    def check_layout_params(self) -> None:
+    def check_layout_params(self):
         """Check that the layout.json is consistent with install.json.
 
         The layout.json files references the params.name from the install.json file.  The method
@@ -393,7 +393,7 @@ class Validate(BinABC):
         # update validation data for module
         self.validation_data['layouts'].append({'params': 'outputs', 'status': status})
 
-    def check_syntax(self, app_path=None) -> None:
+    def check_syntax(self, app_path=None):
         """Run syntax on each ".py" and ".json" file.
 
         Args:
@@ -439,7 +439,7 @@ class Validate(BinABC):
             # store status for this file
             self.validation_data['fileSyntax'].append({'filename': fqfn.name, 'status': status})
 
-    def interactive(self) -> None:
+    def interactive(self):
         """[App Builder] Run in interactive mode."""
         while True:
             line = sys.stdin.readline().strip()
@@ -456,12 +456,12 @@ class Validate(BinABC):
             # reset validation_data
             self.validation_data = self._validation_data
 
-    def print_json(self) -> None:
+    def print_json(self):
         """[App Builder] Print JSON output."""
         print(json.dumps({'validation_data': self.validation_data}))
 
     # TODO: [low] switch to typer echo?
-    def _print_file_syntax_results(self) -> None:
+    def _print_file_syntax_results(self):
         """Print file syntax results."""
         if self.validation_data.get('fileSyntax'):
             print(f'\n{c.Style.BRIGHT}{c.Fore.BLUE}Validated File Syntax:')
@@ -471,7 +471,7 @@ class Validate(BinABC):
                 status_value = self.status_value(f.get('status'))
                 print(f"{f.get('filename')!s:<60}{status_color}{status_value!s:<25}")
 
-    def _print_imports_results(self) -> None:
+    def _print_imports_results(self):
         """Print import results."""
         if self.validation_data.get('moduleImports'):
             print(f'\n{c.Style.BRIGHT}{c.Fore.BLUE}Validated Imports:')
@@ -484,7 +484,7 @@ class Validate(BinABC):
                     f'''{f.get('module')!s:<30}{status_color}{status_value!s:<25}'''
                 )
 
-    def _print_schema_results(self) -> None:
+    def _print_schema_results(self):
         """Print schema results."""
         if self.validation_data.get('schema'):
             print(f'\n{c.Style.BRIGHT}{c.Fore.BLUE}Validated Schema:')
@@ -494,7 +494,7 @@ class Validate(BinABC):
                 status_value = self.status_value(f.get('status'))
                 print(f'''{f.get('filename')!s:<60}{status_color}{status_value!s:<25}''')
 
-    def _print_layouts_results(self) -> None:
+    def _print_layouts_results(self):
         """Print layout results."""
         if self.validation_data.get('layouts'):
             print(f'\n{c.Style.BRIGHT}{c.Fore.BLUE}Validated Layouts:')
@@ -504,7 +504,7 @@ class Validate(BinABC):
                 status_value = self.status_value(f.get('status'))
                 print(f"{f.get('params')!s:<60}{status_color}{status_value!s:<25}")
 
-    def _print_feed_results(self) -> None:
+    def _print_feed_results(self):
         """Print feed results."""
         if self.validation_data.get('feeds'):
             print(f'\n{c.Style.BRIGHT}{c.Fore.BLUE}Validated Feed Jobs:')
@@ -514,7 +514,7 @@ class Validate(BinABC):
                 status_value = self.status_value(f.get('status'))
                 print(f"{f.get('name')!s:<60}{status_color}{status_value!s:<25}")
 
-    def _print_errors(self) -> None:
+    def _print_errors(self):
         """Print errors results."""
         if self.validation_data.get('errors'):
             print('\n')  # separate errors from normal output
@@ -526,7 +526,7 @@ class Validate(BinABC):
             if not self.ignore_validation:
                 self.exit_code = 1
 
-    def print_results(self) -> None:
+    def print_results(self):
         """Print results."""
         # Validating Syntax
         self._print_file_syntax_results()

--- a/tcex/exit/error_codes.py
+++ b/tcex/exit/error_codes.py
@@ -96,7 +96,7 @@ def handle_error(
     message_values: Optional[list] = None,
     raise_error: Optional[bool] = True,
     cause: Optional[Exception] = None,
-) -> None:
+):
     """Log a defined error and optionally raises a RuntimeError."""
     try:
         if message_values is None:

--- a/tcex/exit/exit.py
+++ b/tcex/exit/exit.py
@@ -43,7 +43,7 @@ class ExitService:
         self._exit_code = ExitCode.SUCCESS
 
     @property
-    def exit_code(self) -> ExitCode:
+    def exit_code(self) -> 'ExitCode':
         """Get exit code."""
         return self._exit_code
 
@@ -68,7 +68,7 @@ class ExitService:
             exit_code = ExitCode.SUCCESS
         self._exit_code = exit_code
 
-    def exit(self, code: Optional[Union[ExitCode, int]] = None, msg: Optional[str] = None) -> None:
+    def exit(self, code: Optional[Union[ExitCode, int]] = None, msg: Optional[str] = None):
         """Application exit method with proper exit code
 
         The method will run the Python standard sys.exit() with the exit code
@@ -108,7 +108,7 @@ class ExitService:
     # pylint: disable=unused-argument
     def exit_aot_terminate(
         self, code: Optional[Union[ExitCode, int]] = None, msg: Optional[str] = None
-    ) -> None:
+    ):
         """Application exit method with proper exit code only for AOT.
 
         The method will run the Python standard sys.exit() with the exit code
@@ -129,7 +129,7 @@ class ExitService:
         logger.info(f'exit-code={code}')
         sys.exit(code)
 
-    def exit_playbook_handler(self, msg: str) -> None:
+    def exit_playbook_handler(self, msg: str):
         """Perform special action for PB Apps before exit."""
         # write outputs before exiting
         registry.playbook.output.process()  # pylint: disable=no-member
@@ -143,7 +143,7 @@ class ExitService:
                 self.inputs.model_unresolved.tcex_testing_context, '_exit_message', msg
             )
 
-    def _exit_msg_handler(self, code: ExitCode, msg: str) -> None:
+    def _exit_msg_handler(self, code: ExitCode, msg: str):
         """Handle exit message. Write to both log and message_tc."""
         if msg is not None:
             log_msg = msg.replace('\n', ',')
@@ -153,7 +153,7 @@ class ExitService:
                 logger.error(f'exit-message="{log_msg}"')
             self._message_tc(msg)
 
-    def _aot_rpush(self, exit_code: int) -> None:
+    def _aot_rpush(self, exit_code: int):
         """Push message to AOT action channel."""
         if self.inputs.contents.get('tc_playbook_db_type') == 'Redis':
             try:
@@ -162,7 +162,7 @@ class ExitService:
             except Exception as e:  # pragma: no cover
                 self._exit(ExitCode.FAILURE, f'Exception during AOT exit push ({e}).')
 
-    def _message_tc(self, message: str, max_length: Optional[int] = 255) -> None:
+    def _message_tc(self, message: str, max_length: Optional[int] = 255):
         """Write data to message_tc file in TcEX specified directory.
 
         This method is used to set and exit message in the ThreatConnect Platform.

--- a/tcex/input/field_types/integer.py
+++ b/tcex/input/field_types/integer.py
@@ -25,10 +25,10 @@ class Integer(int):
     lt: OptionalInt = None
 
     @classmethod
-    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+    def __modify_schema__(cls, field_schema: Dict[str, Any]):
         """Modify the field schema."""
 
-        def update_not_none(mapping: Dict[Any, Any], **update: Any) -> None:
+        def update_not_none(mapping: Dict[Any, Any], **update: Any):
             mapping.update({k: v for k, v in update.items() if v is not None})
 
         update_not_none(

--- a/tcex/input/field_types/sensitive.py
+++ b/tcex/input/field_types/sensitive.py
@@ -50,10 +50,10 @@ class Sensitive:
         return len(self._sensitive_value)
 
     @classmethod
-    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+    def __modify_schema__(cls, field_schema: Dict[str, Any]):
         """Modify the field schema."""
 
-        def _update_not_none(mapping: Dict[Any, Any], **update: Any) -> None:
+        def _update_not_none(mapping: Dict[Any, Any], **update: Any):
             mapping.update({k: v for k, v in update.items() if v is not None})
 
         _update_not_none(

--- a/tcex/input/input.py
+++ b/tcex/input/input.py
@@ -32,7 +32,7 @@ logger = logging.getLogger('tcex')
 json_encoders = {Sensitive: lambda v: str(v)}  # pylint: disable=W0108
 
 
-def input_model(models: list) -> BaseModel:
+def input_model(models: list) -> 'BaseModel':
     """Return Input Model."""
 
     class InputModel(*models):
@@ -59,9 +59,7 @@ def input_model(models: list) -> BaseModel:
 class Input:
     """Module to handle inputs for all App types."""
 
-    def __init__(
-        self, config: Optional[dict] = None, config_file: Optional[str] = None, **kwargs
-    ) -> None:
+    def __init__(self, config: Optional[dict] = None, config_file: Optional[str] = None, **kwargs):
         """Initialize class properties.
 
         Keyword Args:
@@ -203,7 +201,7 @@ class Input:
 
         return file_content
 
-    def add_model(self, model: BaseModel) -> None:
+    def add_model(self, model: BaseModel):
         """Add additional input models."""
         if model:
             self._models.insert(0, model)
@@ -304,7 +302,7 @@ class Input:
         return dict(sorted(_inputs.items()))
 
     # TODO: [high] - can this be replaced with a pydantic root validator?
-    def contents_update(self, inputs: dict) -> None:
+    def contents_update(self, inputs: dict):
         """Update inputs provided by AOT to be of the proper value and type."""
         for name, value in inputs.items():
             # ThreatConnect AOT params could be updated in the future to proper JSON format.
@@ -324,12 +322,12 @@ class Input:
                 inputs[name] = value.lower() == 'true'
 
     @cached_property
-    def model(self) -> BaseModel:
+    def model(self) -> 'BaseModel':
         """Return the Input Model."""
         return input_model(self.models)(**self.contents_resolved)
 
     @cached_property
-    def model_unresolved(self) -> BaseModel:
+    def model_unresolved(self) -> 'BaseModel':
         """Return the Input Model using contents (no resolved values)."""
         return input_model(self.models)(**self.contents)
 
@@ -398,7 +396,7 @@ class Input:
         return data
 
     @staticmethod
-    def validation_exit_message(ex: 'ValidationError') -> None:
+    def validation_exit_message(ex: 'ValidationError'):
         """Format and return validation error message."""
         _exit_message = {}
         for err in ex.errors():

--- a/tcex/key_value_store/key_value_api.py
+++ b/tcex/key_value_store/key_value_api.py
@@ -15,7 +15,7 @@ class KeyValueApi(KeyValueABC):
         session: A configured requests session for TC API (tcex.session).
     """
 
-    def __init__(self, session: object) -> None:
+    def __init__(self, session: object):
         """Initialize the Class properties."""
         self._session = session
 

--- a/tcex/key_value_store/key_value_redis.py
+++ b/tcex/key_value_store/key_value_redis.py
@@ -25,7 +25,7 @@ class KeyValueRedis(KeyValueABC):
         # properties
         self.kv_type = 'redis'
 
-    def create(self, context: str, key: str, value: Any) -> None:
+    def create(self, context: str, key: str, value: Any):
         """Create key/value pair in Redis.
 
         Args:

--- a/tcex/key_value_store/redis_client.py
+++ b/tcex/key_value_store/redis_client.py
@@ -34,7 +34,7 @@ class RedisClient:
         db: Optional[int] = 0,
         blocking_pool: Optional[bool] = False,
         **kwargs
-    ) -> None:
+    ):
         """Initialize class properties"""
         pool = redis.ConnectionPool
         if blocking_pool:
@@ -43,6 +43,6 @@ class RedisClient:
         self.pool = pool(host=host, port=port, db=db, **kwargs)
 
     @cached_property
-    def client(self) -> redis.Redis:
+    def client(self) -> 'redis.Redis':
         """Return an instance of redis.client.Redis."""
         return redis.Redis(connection_pool=self.pool)

--- a/tcex/logger/logger.py
+++ b/tcex/logger/logger.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 class Logger:
     """Framework logger module."""
 
-    def __init__(self, logger_name: str) -> None:
+    def __init__(self, logger_name: str):
         """Initialize Class Properties."""
         self.logger_name = logger_name
 
@@ -34,7 +34,7 @@ class Logger:
         self.ij = InstallJson()
 
     @property
-    def _logger(self) -> logging.Logger:
+    def _logger(self) -> 'logging.Logger':
         """Return the logger. The inputs.model property is not available in init."""
         logging.setLoggerClass(TraceLogger)
         logger = logging.getLogger(self.logger_name)
@@ -42,7 +42,7 @@ class Logger:
         return logger
 
     @property
-    def _formatter(self) -> None:
+    def _formatter(self):
         """Return log formatter."""
         tx_format = (
             '%(asctime)s - %(name)s - %(levelname)8s - %(message)s '
@@ -51,7 +51,7 @@ class Logger:
         return logging.Formatter(tx_format)
 
     @property
-    def _formatter_thread_name(self) -> None:
+    def _formatter_thread_name(self):
         """Return log formatter."""
         tx_format = (
             '%(asctime)s - %(name)s - %(levelname)8s - %(message)s '
@@ -74,7 +74,7 @@ class Logger:
         return False
 
     @property
-    def log(self) -> logging.Logger:
+    def log(self) -> 'logging.Logger':
         """Return logger."""
         return self._logger
 
@@ -91,7 +91,7 @@ class Logger:
         level = level or 'debug'
         return logging.getLevelName(level.upper())
 
-    def remove_handler_by_name(self, handler_name: str) -> None:
+    def remove_handler_by_name(self, handler_name: str):
         """Remove a file handler by name.
 
         Args:
@@ -102,7 +102,7 @@ class Logger:
                 self._logger.removeHandler(h)
                 break
 
-    def replay_cached_events(self, handler_name: Optional[str] = 'cache') -> None:
+    def replay_cached_events(self, handler_name: Optional[str] = 'cache'):
         """Replay cached log events and remove handler."""
         for h in self._logger.handlers:
             if h.get_name() == handler_name:
@@ -115,7 +115,7 @@ class Logger:
         # remove the cache handler
         self.remove_handler_by_name(handler_name=handler_name)
 
-    def shutdown(self) -> None:
+    def shutdown(self):
         """Close all handlers.
 
         Args:
@@ -124,7 +124,7 @@ class Logger:
         for h in self._logger.handlers:
             self._logger.removeHandler(h)
 
-    def update_handler_level(self, level: str) -> None:
+    def update_handler_level(self, level: str):
         """Update all handlers log level.
 
         Args:
@@ -142,7 +142,7 @@ class Logger:
 
     def add_api_handler(
         self, session_tc: 'Session', name: Optional[str] = 'api', level: Optional[str] = None
-    ) -> None:
+    ):
         """Add API logging handler.
 
         Args:
@@ -157,7 +157,7 @@ class Logger:
         api.setFormatter(ApiHandlerFormatter())
         self._logger.addHandler(api)
 
-    def add_cache_handler(self, name: str) -> None:
+    def add_cache_handler(self, name: str):
         """Add cache logging handler.
 
         Args:
@@ -183,7 +183,7 @@ class Logger:
         handler_key: Optional[str] = None,
         max_log_count: Optional[int] = 100,
         thread_key: Optional[str] = None,
-    ) -> None:
+    ):
         """Add custom file logging handler.
 
         This handler is intended for service Apps that need to log events based on the
@@ -224,7 +224,7 @@ class Logger:
         level: str,
         formatter: Optional[str] = None,
         mode: Optional[str] = 'a',
-    ) -> None:
+    ):
         """Add custom file logging handler.
 
         Args:
@@ -254,7 +254,7 @@ class Logger:
         name: Optional[str] = 'sh',
         formatter: Optional[str] = None,
         level: Optional[int] = None,
-    ) -> None:
+    ):
         """Add stream logging handler.
 
         Args:
@@ -283,7 +283,7 @@ class Logger:
         max_bytes: Optional[int] = 0,
         mode: Optional[str] = 'a',
         thread_key: Optional[str] = None,
-    ) -> None:
+    ):
         """Add custom file logging handler.
 
         This handler is intended for service Apps that need to log events based on the
@@ -319,7 +319,7 @@ class Logger:
     # App info logging
     #
 
-    def log_info(self, inputs: 'BaseModel') -> None:
+    def log_info(self, inputs: 'BaseModel'):
         """Send System and App data to logs.
 
         Args:
@@ -331,7 +331,7 @@ class Logger:
         self._log_tcex_version()
         self._log_tc_proxy(inputs)
 
-    def _log_app_data(self) -> None:
+    def _log_app_data(self):
         """Log the App data information as a best effort."""
         try:
             self.log.info(f'app-name="{self.ij.model.display_name}"')
@@ -346,12 +346,12 @@ class Logger:
         except Exception:  # nosec; pragma: no cover
             pass
 
-    def _log_platform(self) -> None:
+    def _log_platform(self):
         """Log the current Platform."""
         self.log.info(f'platform="{platform.platform()}"')
         self.log.info(f'pid={os.getpid()}')
 
-    def _log_python_version(self) -> None:
+    def _log_python_version(self):
         """Log the current Python version."""
         self.log.info(
             f'python-version={sys.version_info.major}.'
@@ -359,7 +359,7 @@ class Logger:
             f'{sys.version_info.micro}'
         )
 
-    def _log_tc_proxy(self, inputs: 'BaseModel') -> None:
+    def _log_tc_proxy(self, inputs: 'BaseModel'):
         """Log the proxy settings.
 
         Args:
@@ -368,7 +368,7 @@ class Logger:
         if inputs.tc_proxy_tc:
             self.log.info(f'proxy-server-tc={inputs.tc_proxy_host}:{inputs.tc_proxy_port}')
 
-    def _log_tcex_version(self) -> None:
+    def _log_tcex_version(self):
         """Log the current TcEx version number."""
         app_path = str(pathlib.Path().parent.absolute())
         full_path = str(pathlib.Path(__file__).parent.absolute())

--- a/tcex/logger/pattern_file_handler.py
+++ b/tcex/logger/pattern_file_handler.py
@@ -48,7 +48,7 @@ class PatternFileHandler(logging.FileHandler):
 
         super().__init__(filename=filename, mode=mode, encoding=encoding, delay=delay)
 
-    def _trim_log_files(self, filename: str, max_log_count: int) -> None:
+    def _trim_log_files(self, filename: str, max_log_count: int):
         """Trim log files removing the oldest files.
 
         Args:
@@ -77,7 +77,7 @@ class PatternFileHandler(logging.FileHandler):
                 # best effort
                 pass
 
-    def emit(self, record: object) -> None:
+    def emit(self, record: object):
         """Emit a record.
 
         Emit logging events only if handler_key matches thread_key.

--- a/tcex/logger/rotating_file_handler_custom.py
+++ b/tcex/logger/rotating_file_handler_custom.py
@@ -49,7 +49,7 @@ class RotatingFileHandlerCustom(RotatingFileHandler):
         return name + '.gz'
 
     @staticmethod
-    def custom_gzip_rotator(source: str, dest: str) -> None:
+    def custom_gzip_rotator(source: str, dest: str):
         """Rotate and compress log file.
 
         Args:

--- a/tcex/logger/sensitive_filter.py
+++ b/tcex/logger/sensitive_filter.py
@@ -11,7 +11,7 @@ class SensitiveFilter(logging.Filter):
         super().__init__(name)
         self._sensitive_registry = set()
 
-    def add(self, value: str) -> None:
+    def add(self, value: str):
         """Add sensitive value to registry."""
         if value:
             # don't add empty string

--- a/tcex/logger/thread_file_handler.py
+++ b/tcex/logger/thread_file_handler.py
@@ -37,7 +37,7 @@ class ThreadFileHandler(RotatingFileHandler):
             os.makedirs(os.path.dirname(filename), exist_ok=True)
         RotatingFileHandler.__init__(self, filename, mode, maxBytes, backupCount, encoding, delay)
 
-    def emit(self, record: object) -> None:
+    def emit(self, record: object):
         """Emit a record.
 
         Emit logging events only if handler_key matches thread_key.

--- a/tcex/playbook/playbook.py
+++ b/tcex/playbook/playbook.py
@@ -32,7 +32,7 @@ class Playbook:
         key_value_store: Union[KeyValueApi, KeyValueRedis],
         context: Optional[str] = None,
         output_variables: Optional[list] = None,
-    ) -> None:
+    ):
         """Initialize the class properties."""
         self.context = context
         self.key_value_store = key_value_store

--- a/tcex/playbook/playbook_create.py
+++ b/tcex/playbook/playbook_create.py
@@ -36,7 +36,7 @@ class PlaybookCreate:
         self.utils = Utils()
 
     @staticmethod
-    def _check_iterable(value: str, validate: bool) -> None:
+    def _check_iterable(value: str, validate: bool):
         """Raise an exception if value is not an Iterable.
 
         Validation:
@@ -71,7 +71,7 @@ class PlaybookCreate:
 
         return invalid
 
-    def _check_requested(self, variable: str, when_requested: bool) -> None:
+    def _check_requested(self, variable: str, when_requested: bool):
         """Return True if output variable was requested by downstream app."""
         if when_requested is True and not self.is_requested(variable):
             self.log.debug(f'Variable {variable} was NOT requested by downstream app.')
@@ -99,7 +99,7 @@ class PlaybookCreate:
 
         return value
 
-    def _create_data(self, key: str, value: Any) -> None:
+    def _create_data(self, key: str, value: Any):
         """Write data to key value store."""
         self.log.debug(f'writing variable {key.strip()}')
         try:

--- a/tcex/playbook/playbook_output.py
+++ b/tcex/playbook/playbook_output.py
@@ -18,7 +18,7 @@ class PlaybookOutput(dict):
         playbook: An instance of Playbook.
     """
 
-    def __init__(self, playbook: 'Playbook') -> None:
+    def __init__(self, playbook: 'Playbook'):
         """Initialize the class properties."""
         super().__init__()
         self.playbook = playbook

--- a/tcex/pleb/env_path.py
+++ b/tcex/pleb/env_path.py
@@ -17,7 +17,7 @@ class EnvPath(Path):
     """EnvPath custom pydantic model type."""
 
     @classmethod
-    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+    def __modify_schema__(cls, field_schema: Dict[str, Any]):
         """."""
         field_schema.update(format='file-path')
 
@@ -27,7 +27,7 @@ class EnvPath(Path):
         yield cls.validate
 
     @classmethod
-    def validate(cls, value: Union[str, Path]) -> Path:
+    def validate(cls, value: Union[str, 'Path']) -> 'Path':
         """Replace any environment variables in the tcex.json file."""
         if isinstance(value, Path):
             return value

--- a/tcex/pleb/event.py
+++ b/tcex/pleb/event.py
@@ -10,7 +10,7 @@ class Event(metaclass=Singleton):
         """."""
         self.channels = {}
 
-    def send(self, channel: str, **kwargs) -> None:
+    def send(self, channel: str, **kwargs):
         """Send message to channel."""
         for callback in self.channels.get(channel, []):
             callback(**kwargs)

--- a/tcex/pleb/none_model.py
+++ b/tcex/pleb/none_model.py
@@ -16,6 +16,6 @@ class Singleton(type):
 class NoneModel(metaclass=Singleton):
     """A dummy model that return None for all attribute requests."""
 
-    def __getattribute__(self, name: str) -> None:
+    def __getattribute__(self, name: str):
         """Return None for any attribute request."""
         return None

--- a/tcex/pleb/threading.py
+++ b/tcex/pleb/threading.py
@@ -14,7 +14,7 @@ class ExceptionThread(threading.Thread):
         super().__init__(*args, **kwargs)
         self.exception = None
 
-    def run(self) -> None:
+    def run(self):
         """Run thread logic"""
         try:
             super().run()

--- a/tcex/services/api_service.py
+++ b/tcex/services/api_service.py
@@ -102,7 +102,7 @@ class ApiService(CommonService):
             self.log.trace(traceback.format_exc())
         return headers_
 
-    def process_run_service_response(self, *args, **kwargs) -> None:
+    def process_run_service_response(self, *args, **kwargs):
         """Handle service event responses.
 
         ('200 OK', [('content-type', 'application/json'), ('content-length', '103')])
@@ -131,7 +131,7 @@ class ApiService(CommonService):
             self.log.trace(traceback.format_exc())
             self.increment_metric('Errors')
 
-    def process_run_service_command(self, message: dict) -> None:
+    def process_run_service_command(self, message: dict):
         """Process the RunService command.
 
         .. code-block:: python

--- a/tcex/services/common_service.py
+++ b/tcex/services/common_service.py
@@ -76,9 +76,7 @@ class CommonService:
             thread_key='session_id',
         )
 
-    def process_acknowledged_command(
-        self, message: dict
-    ) -> None:  # pylint: disable=unused-argument
+    def process_acknowledged_command(self, message: dict):  # pylint: disable=unused-argument
         """Process the Acknowledge command.
 
         Args:
@@ -86,7 +84,7 @@ class CommonService:
         """
         self.log.info(f'feature=service, event=acknowledge, message={message}')
 
-    def add_metric(self, label: str, value: Union[int, str]) -> None:
+    def add_metric(self, label: str, value: Union[int, str]):
         """Add a metric.
 
         Metrics are reported in heartbeat message.
@@ -117,11 +115,11 @@ class CommonService:
         """
         return str(uuid.uuid4())
 
-    def heartbeat(self) -> None:
+    def heartbeat(self):
         """Start heartbeat process."""
         self.service_thread(name='heartbeat', target=self.heartbeat_monitor)
 
-    def heartbeat_broker_check(self) -> None:
+    def heartbeat_broker_check(self):
         """Send self check message to ensure communications with message broker."""
         message = {
             'command': 'BrokerCheck',
@@ -135,7 +133,7 @@ class CommonService:
         # allow time for message to be received
         time.sleep(5)
 
-    def heartbeat_monitor(self) -> None:
+    def heartbeat_monitor(self):
         """Publish heartbeat on timer."""
         self.log.info('feature=service, event=heartbeat-monitor-started')
         while True:
@@ -154,7 +152,7 @@ class CommonService:
             time.sleep(self.heartbeat_sleep_time)
             self.heartbeat_watchdog += 1
 
-    def increment_metric(self, label: str, value: Optional[int] = 1) -> None:
+    def increment_metric(self, label: str, value: Optional[int] = 1):
         """Increment a metric if already exists.
 
         Args:
@@ -164,7 +162,7 @@ class CommonService:
         if self._metrics.get(label) is not None:
             self._metrics[label] += value
 
-    def listen(self) -> None:
+    def listen(self):
         """List for message coming from broker."""
         self.message_broker.add_on_connect_callback(self.on_connect_handler)
         self.message_broker.add_on_message_callback(
@@ -208,9 +206,7 @@ class CommonService:
         else:
             self.log.error('feature=service, event=invalid-metrics')
 
-    def on_connect_handler(
-        self, client, userdata, flags, rc  # pylint: disable=unused-argument
-    ) -> None:
+    def on_connect_handler(self, client, userdata, flags, rc):  # pylint: disable=unused-argument
         """On connect method for mqtt broker."""
         self.log.info(
             f'feature=service, event=topic-subscription, topic={self.args.tc_svc_server_topic}'
@@ -218,9 +214,7 @@ class CommonService:
         self.message_broker.client.subscribe(self.args.tc_svc_server_topic)
         self.message_broker.client.disable_logger()
 
-    def on_message_handler(
-        self, client, userdata, message  # pylint: disable=unused-argument
-    ) -> None:
+    def on_message_handler(self, client, userdata, message):  # pylint: disable=unused-argument
         """On message for mqtt."""
         try:
             # messages on server topic must be json objects
@@ -254,7 +248,7 @@ class CommonService:
             trigger_id=trigger_id,
         )
 
-    def process_broker_check(self, message: dict) -> None:
+    def process_broker_check(self, message: dict):
         """Implement parent method to log a broker check message.
 
         .. code-block:: python
@@ -270,7 +264,7 @@ class CommonService:
         """
         self.log.warning(f'feature=service, event=broker-check, message={message}')
 
-    def process_heartbeat_command(self, message: dict) -> None:  # pylint: disable=unused-argument
+    def process_heartbeat_command(self, message: dict):  # pylint: disable=unused-argument
         """Process the HeartBeat command.
 
         .. code-block:: python
@@ -296,7 +290,7 @@ class CommonService:
         )
         self.log.info(f'feature=service, event=heartbeat-sent, metrics={self.metrics}')
 
-    def process_logging_change_command(self, message: dict) -> None:
+    def process_logging_change_command(self, message: dict):
         """Process the LoggingChange command.
 
         .. code-block:: python
@@ -315,7 +309,7 @@ class CommonService:
         self.log.info(f'feature=service, event=logging-change, level={level}')
         self.logger.update_handler_level(level)
 
-    def process_invalid_command(self, message: dict) -> None:
+    def process_invalid_command(self, message: dict):
         """Process all invalid commands.
 
         Args:
@@ -325,7 +319,7 @@ class CommonService:
             f'feature=service, event=invalid-command-received, message="""({message})""".'
         )
 
-    def process_shutdown_command(self, message: dict) -> None:
+    def process_shutdown_command(self, message: dict):
         """Implement parent method to process the shutdown command.
 
         .. code-block:: python
@@ -406,7 +400,7 @@ class CommonService:
         kwargs: Optional[dict] = None,
         session_id: Optional[str] = None,
         trigger_id: Optional[int] = None,
-    ) -> None:
+    ):
         """Start a message thread.
 
         Args:
@@ -451,7 +445,7 @@ class CommonService:
                 trigger_id = int(trigger_id)
         return trigger_id
 
-    def update_metric(self, label: str, value: Union[int, str]) -> None:
+    def update_metric(self, label: str, value: Union[int, str]):
         """Update a metric if already exists.
 
         Args:

--- a/tcex/services/common_service_trigger.py
+++ b/tcex/services/common_service_trigger.py
@@ -37,7 +37,7 @@ class CommonServiceTrigger(CommonService):
         self.delete_config_callback = None
         self.trigger_input_model = None
 
-    def _tcex_testing(self, session_id: str, trigger_id: int) -> None:
+    def _tcex_testing(self, session_id: str, trigger_id: int):
         """Write data required for testing framework to Redis.
 
         Args:
@@ -63,7 +63,7 @@ class CommonServiceTrigger(CommonService):
                 f'context={session_id}, trigger-id={trigger_id}'
             )
 
-    def _tcex_testing_fired_events(self, session_id: str, fired: bool) -> None:
+    def _tcex_testing_fired_events(self, session_id: str, fired: bool):
         """Write fired event data to KV Store to be used in test validation.
 
         Args:
@@ -87,7 +87,7 @@ class CommonServiceTrigger(CommonService):
         )
         return command_map
 
-    def create_config(self, trigger_id: int, message: str, status: bool) -> None:
+    def create_config(self, trigger_id: int, message: str, status: bool):
         """Add config item to service config object.
 
         Args:
@@ -125,7 +125,7 @@ class CommonServiceTrigger(CommonService):
             )
             self.log.trace(traceback.format_exc())
 
-    def delete_config(self, trigger_id: int, message: str, status: str) -> None:
+    def delete_config(self, trigger_id: int, message: str, status: str):
         """Delete config item from config object.
 
         Args:
@@ -157,7 +157,7 @@ class CommonServiceTrigger(CommonService):
             )
             # self.log.trace(traceback.format_exc())
 
-    def fire_event(self, callback: Callable[[], bool], **kwargs) -> None:
+    def fire_event(self, callback: Callable[[], bool], **kwargs):
         """Trigger a FireEvent command.
 
         Args:
@@ -211,7 +211,7 @@ class CommonServiceTrigger(CommonService):
             except Exception:
                 self.log.trace(traceback.format_exc())
 
-    def update_trigger_value(self, trigger_id: int, input_name: str, new_value: Any) -> None:
+    def update_trigger_value(self, trigger_id: int, input_name: str, new_value: Any):
         """Send UpdateTriggerValue command.
 
         Args:
@@ -232,7 +232,7 @@ class CommonServiceTrigger(CommonService):
 
     def fire_event_publish(
         self, trigger_id: int, session_id: str, request_key: Optional[str] = None
-    ) -> None:
+    ):
         """Send FireEvent command.
 
         Args:
@@ -260,7 +260,7 @@ class CommonServiceTrigger(CommonService):
         trigger_id: int,
         config: dict,
         **kwargs: str,
-    ) -> None:
+    ):
         """Fire event for trigger.
 
         Args:
@@ -298,7 +298,7 @@ class CommonServiceTrigger(CommonService):
         finally:
             self.logger.remove_handler_by_name(self.thread_name)
 
-    def log_config(self, trigger_id: str, config: dict) -> None:
+    def log_config(self, trigger_id: str, config: dict):
         """Log the config while hiding encrypted values.
 
         Args:
@@ -315,7 +315,7 @@ class CommonServiceTrigger(CommonService):
             f'feature=service, event=create-config, trigger_id={trigger_id}, config={logged_config}'
         )
 
-    def process_create_config_command(self, message: dict) -> None:
+    def process_create_config_command(self, message: dict):
         """Process the CreateConfig command.
 
         .. code-block:: python
@@ -411,7 +411,7 @@ class CommonServiceTrigger(CommonService):
         # create config after callback to report status and message
         self.create_config(trigger_id, msg, status)
 
-    def process_delete_config_command(self, message: dict) -> None:
+    def process_delete_config_command(self, message: dict):
         """Process the DeleteConfig command.
 
         .. code-block:: python

--- a/tcex/services/mqtt_message_broker.py
+++ b/tcex/services/mqtt_message_broker.py
@@ -57,7 +57,7 @@ class MqttMessageBroker:
         self.log = logger
         self.shutdown = False  # used in service App for shutdown flag
 
-    def add_on_connect_callback(self, callback: callable, index: Optional[int] = None) -> None:
+    def add_on_connect_callback(self, callback: callable, index: Optional[int] = None):
         """Add a callback for on_connect events.
 
         Args:
@@ -67,7 +67,7 @@ class MqttMessageBroker:
         index = index or len(self._on_connect_callbacks)
         self._on_connect_callbacks.insert(index, callback)
 
-    def add_on_disconnect_callback(self, callback: callable, index: Optional[int] = None) -> None:
+    def add_on_disconnect_callback(self, callback: callable, index: Optional[int] = None):
         """Add a callback for on_disconnect events.
 
         Args:
@@ -77,7 +77,7 @@ class MqttMessageBroker:
         index = index or len(self._on_disconnect_callbacks)
         self._on_disconnect_callbacks.insert(callback)
 
-    def add_on_log_callback(self, callback: callable, index: Optional[int] = None) -> None:
+    def add_on_log_callback(self, callback: callable, index: Optional[int] = None):
         """Add a callback for on_log events.
 
         Args:
@@ -89,7 +89,7 @@ class MqttMessageBroker:
 
     def add_on_message_callback(
         self, callback: callable, index: Optional[int] = None, topics: Optional[List[str]] = None
-    ) -> None:
+    ):
         """Add a callback for on_message events.
 
         Args:
@@ -101,7 +101,7 @@ class MqttMessageBroker:
         index = index or len(self._on_message_callbacks)
         self._on_message_callbacks.insert(index, {'callback': callback, 'topics': topics})
 
-    def add_on_publish_callback(self, callback: callable, index: Optional[int] = None) -> None:
+    def add_on_publish_callback(self, callback: callable, index: Optional[int] = None):
         """Add a callback for on_publish events.
 
         Args:
@@ -111,7 +111,7 @@ class MqttMessageBroker:
         index = index or len(self._on_publish_callbacks)
         self._on_publish_callbacks.insert(index, callback)
 
-    def add_on_subscribe_callback(self, callback: callable, index: Optional[int] = None) -> None:
+    def add_on_subscribe_callback(self, callback: callable, index: Optional[int] = None):
         """Add a callback for on_subscribe events.
 
         Args:
@@ -121,7 +121,7 @@ class MqttMessageBroker:
         index = index or len(self._on_subscribe_callbacks)
         self._on_subscribe_callbacks.insert(index, callback)
 
-    def add_on_unsubscribe_callback(self, callback: callable, index: Optional[int] = None) -> None:
+    def add_on_unsubscribe_callback(self, callback: callable, index: Optional[int] = None):
         """Add a callback for on_unsubscribe events.
 
         Args:
@@ -159,7 +159,7 @@ class MqttMessageBroker:
 
         return self._client
 
-    def connect(self) -> None:
+    def connect(self):
         """Listen for message coming from broker."""
         try:
             # handle connection issues by not using loop_forever. give the service X seconds to
@@ -180,26 +180,26 @@ class MqttMessageBroker:
             self.log.trace(f'feature=message-broker, event=connection-error, error="""{e}"""')
             self.log.error(traceback.format_exc())
 
-    def on_connect(self, client, userdata, flags, rc) -> None:
+    def on_connect(self, client, userdata, flags, rc):
         """Handle MQTT on_connect events."""
         self.log.info(f'feature=message-broker, event=broker-connect, status={str(rc)}')
         self._connected = True
         for callback in self._on_connect_callbacks:
             callback(client, userdata, flags, rc)
 
-    def on_disconnect(self, client, userdata, rc) -> None:
+    def on_disconnect(self, client, userdata, rc):
         """Handle MQTT on_disconnect events."""
         self.log.info(f'feature=message-broker, event=broker-disconnect, status={str(rc)}')
         for callback in self._on_disconnect_callbacks:
             callback(client, userdata, rc)
 
-    def on_log(self, client, userdata, level, buf) -> None:
+    def on_log(self, client, userdata, level, buf):
         """Handle MQTT on_log events."""
         # self.log.trace(f'feature=message-broker, event=on_log, buf={buf}, level={level}')
         for callback in self._on_log_callbacks:
             callback(client, userdata, level, buf)
 
-    def on_message(self, client, userdata, message) -> None:
+    def on_message(self, client, userdata, message):
         """Handle MQTT on_message events."""
         mp = message.payload.decode().replace('\n', '')
         self.log.trace(
@@ -210,13 +210,13 @@ class MqttMessageBroker:
             if topics is None or message.topic in topics:
                 cd.get('callback')(client, userdata, message)
 
-    def on_publish(self, client, userdata, result) -> None:
+    def on_publish(self, client, userdata, result):
         """Handle MQTT on_publish events."""
         # self.log.trace(f'feature=message-broker, event=on_publish, result={result}')
         for callback in self._on_publish_callbacks:
             callback(client, userdata, result)
 
-    def on_subscribe(self, client, userdata, mid, granted_qos) -> None:
+    def on_subscribe(self, client, userdata, mid, granted_qos):
         """Handle MQTT on_subscribe events."""
         # self.log.trace(
         #     f'feature=message-broker, event=on_subscribe, mid={mid}, granted_qos={granted_qos}'
@@ -224,13 +224,13 @@ class MqttMessageBroker:
         for callback in self._on_subscribe_callbacks:
             callback(client, userdata, mid, granted_qos)
 
-    def on_unsubscribe(self, client, userdata, mid) -> None:
+    def on_unsubscribe(self, client, userdata, mid):
         """Handle MQTT on_unsubscribe events."""
         # self.log.trace(f'feature=message-broker, event=on_subscribe, mid={mid}')
         for callback in self._on_unsubscribe_callbacks:
             callback(client, userdata, mid)
 
-    def publish(self, message: str, topic: str) -> None:
+    def publish(self, message: str, topic: str):
         """Publish a message on client topic.
 
         Args:
@@ -243,7 +243,7 @@ class MqttMessageBroker:
             f'message={message}, response={r}'
         )
 
-    def register_callbacks(self) -> None:
+    def register_callbacks(self):
         """Register all the message broker callbacks."""
         self.client.on_connect = self.on_connect
         self.client.on_disconnect = self.on_disconnect

--- a/tcex/services/webhook_trigger_service.py
+++ b/tcex/services/webhook_trigger_service.py
@@ -23,7 +23,7 @@ class WebhookTriggerService(CommonServiceTrigger):
         self.webhook_event_callback = None
         self.webhook_marshall_event_callback = None
 
-    def callback_response_handler(self, callback_response: Any, message: dict) -> None:
+    def callback_response_handler(self, callback_response: Any, message: dict):
         """Handle the different types of callback responses.
 
         # Webhook App (default)
@@ -58,7 +58,7 @@ class WebhookTriggerService(CommonServiceTrigger):
         else:
             self.callback_response_webhook(callback_response, message)
 
-    def callback_response_webhook(self, callback_response: Any, message: dict) -> None:
+    def callback_response_webhook(self, callback_response: Any, message: dict):
         """Handle the different types of callback responses.
 
         * Dict - Playbook will not be launched and provided data
@@ -90,7 +90,7 @@ class WebhookTriggerService(CommonServiceTrigger):
             # capture fired status for testing framework
             self._tcex_testing_fired_events(self.session_id, False)
 
-    def callback_response_marshall(self, callback_response: Any, message: dict) -> None:
+    def callback_response_marshall(self, callback_response: Any, message: dict):
         """Handle the different types of callback responses.
 
         # webhookResponseMarshall Feature App
@@ -111,7 +111,7 @@ class WebhookTriggerService(CommonServiceTrigger):
         # handle response the same a normal response
         self.callback_response_webhook(fire_trigger, message)
 
-    def callback_response_service_endpoint(self, callback_response: Any, message: dict) -> None:
+    def callback_response_service_endpoint(self, callback_response: Any, message: dict):
         """Handle the different types of callback responses.
 
         # webhookServiceEndpoint Feature App
@@ -145,7 +145,7 @@ class WebhookTriggerService(CommonServiceTrigger):
         command_map.update({'webhookmarshallevent': self.process_webhook_marshall_event_command})
         return command_map
 
-    def process_webhook_event_command(self, message: dict) -> None:
+    def process_webhook_event_command(self, message: dict):
         """Process the WebhookEvent command.
 
         .. code-block:: python
@@ -242,7 +242,7 @@ class WebhookTriggerService(CommonServiceTrigger):
         finally:
             self.logger.remove_handler_by_name(self.thread_name)
 
-    def process_webhook_marshall_event_command(self, message: dict) -> None:
+    def process_webhook_marshall_event_command(self, message: dict):
         """Process the WebhookMarshallEvent command.
 
         .. code-block:: python
@@ -334,7 +334,7 @@ class WebhookTriggerService(CommonServiceTrigger):
         # webhook responses are for providers that require a subscription req/resp.
         self.publish_webhook_event_response(message, response)
 
-    def publish_webhook_event_acknowledge(self, message: dict) -> None:
+    def publish_webhook_event_acknowledge(self, message: dict):
         """Publish the WebhookEventResponse message.
 
         Args:
@@ -352,7 +352,7 @@ class WebhookTriggerService(CommonServiceTrigger):
             self.args.tc_svc_client_topic,
         )
 
-    def publish_webhook_marshall_event_acknowledge(self, message: dict) -> None:
+    def publish_webhook_marshall_event_acknowledge(self, message: dict):
         """Publish the WebhookEventResponse message.
 
         .. code-block:: python
@@ -381,7 +381,7 @@ class WebhookTriggerService(CommonServiceTrigger):
             self.args.tc_svc_client_topic,
         )
 
-    def publish_webhook_event_response(self, message: dict, callback_response: dict) -> None:
+    def publish_webhook_event_response(self, message: dict, callback_response: dict):
         """Publish the WebhookEventResponse message.
 
         Args:

--- a/tcex/sessions/auth/hmac_auth.py
+++ b/tcex/sessions/auth/hmac_auth.py
@@ -7,9 +7,12 @@ from hashlib import sha256
 from typing import TYPE_CHECKING
 
 # third-party
-from requests import auth, request
+from requests import auth
 
 if TYPE_CHECKING:  # pragma: no cover
+    # third-party
+    from requests import request
+
     # first-party
     from tcex.input.field_types.sensitive import Sensitive
 
@@ -17,7 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class HmacAuth(auth.AuthBase):
     """ThreatConnect HMAC Authorization"""
 
-    def __init__(self, tc_api_access_id: str, tc_api_secret_key: 'Sensitive') -> None:
+    def __init__(self, tc_api_access_id: str, tc_api_secret_key: 'Sensitive'):
         """Initialize the Class properties."""
         # super().__init__()
         auth.AuthBase.__init__(self)
@@ -37,7 +40,7 @@ class HmacAuth(auth.AuthBase):
         # return the header value with access_id and b64 signature value
         return f'TC {self.tc_api_access_id}:{b64encode(hmac_signature).decode()}'
 
-    def __call__(self, r: 'request') -> request:
+    def __call__(self, r: 'request') -> 'request':
         """Add the authorization headers to the request."""
         timestamp = int(time.time())
 

--- a/tcex/sessions/auth/token_auth.py
+++ b/tcex/sessions/auth/token_auth.py
@@ -1,19 +1,23 @@
 """ThreatConnect HMAC Authorization"""
 # standard library
 import time
-from typing import Callable, Union
+from typing import TYPE_CHECKING, Callable, Union
 
 # third-party
-from requests import auth, request
+from requests import auth
 
 # first-party
 from tcex.input.field_types.sensitive import Sensitive
+
+if TYPE_CHECKING:  # pragma: no cover
+    # third-party
+    from requests import request
 
 
 class TokenAuth(auth.AuthBase):
     """ThreatConnect HMAC Authorization"""
 
-    def __init__(self, tc_token: Union[Callable, str, 'Sensitive']) -> None:
+    def __init__(self, tc_token: Union[Callable, str, 'Sensitive']):
         """Initialize the Class properties."""
         # super().__init__()
         auth.AuthBase.__init__(self)
@@ -39,7 +43,7 @@ class TokenAuth(auth.AuthBase):
         # Return formatted token
         return f'TC-Token {_token}'
 
-    def __call__(self, r: request) -> request:
+    def __call__(self, r: 'request') -> 'request':
         """Add the authorization headers to the request."""
         timestamp = int(time.time())
 

--- a/tcex/sessions/external_session.py
+++ b/tcex/sessions/external_session.py
@@ -22,7 +22,7 @@ logger = logging.getLogger('tcex')
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
-def default_too_many_requests_handler(response: Response) -> float:
+def default_too_many_requests_handler(response: 'Response') -> float:
     """Implement 429 response handling that uses the Retry-After header.
 
     Will return the value in Retry-After.  See: https://tools.ietf.org/html/rfc6585#page-3.
@@ -103,12 +103,12 @@ class CustomAdapter(adapters.HTTPAdapter):
         return response
 
     @property
-    def rate_limit_handler(self) -> RateLimitHandler:
+    def rate_limit_handler(self) -> 'RateLimitHandler':
         """Get the RateLimitHandler."""
         return self._rate_limit_handler
 
     @rate_limit_handler.setter
-    def rate_limit_handler(self, rate_limit_handler: RateLimitHandler) -> None:
+    def rate_limit_handler(self, rate_limit_handler: 'RateLimitHandler'):
         """Set the RateLimitHandler."""
         self._rate_limit_handler = rate_limit_handler
 
@@ -214,7 +214,7 @@ class ExternalSession(Session):
         self._mask_patterns = patterns
 
     @property
-    def too_many_requests_handler(self) -> Callable[[Response], float]:
+    def too_many_requests_handler(self) -> Callable[['Response'], float]:
         """Get the too_many_requests_handler.
 
         The too_many_requests_handler is responsible for determining how long to sleep (in seconds)
@@ -238,7 +238,7 @@ class ExternalSession(Session):
         self._too_many_requests_handler = too_many_requests_handler
 
     @property
-    def rate_limit_handler(self) -> RateLimitHandler:
+    def rate_limit_handler(self) -> 'RateLimitHandler':
         """Return the RateLimitHandler.
 
         The RateLimitHandler is responsible for throttling request frequency.  The default

--- a/tcex/sessions/rate_limit_handler.py
+++ b/tcex/sessions/rate_limit_handler.py
@@ -80,7 +80,7 @@ class RateLimitHandler:
         """Set the threshold for remaining requests."""
         self._remaining_threshold = remaining_threshold
 
-    def post_send(self, response: Response) -> None:
+    def post_send(self, response: Response):
         """Extract rate-limiting information from a response after a request has been sent.
 
         Args:
@@ -96,7 +96,7 @@ class RateLimitHandler:
             )
             self._last_limit_reset_value = response.headers.get(self.limit_reset_header)
 
-    def pre_send(self, request: PreparedRequest) -> None:
+    def pre_send(self, request: PreparedRequest):
         """Call before request is sent and provides an opportunity to pause for rate limiting.
 
         Compares rate-limit values from prior requests to determine if we should wait before sending
@@ -112,7 +112,7 @@ class RateLimitHandler:
         ):
             self.sleep(request)
 
-    def sleep(self, request: PreparedRequest) -> None:  # pylint: disable=unused-argument
+    def sleep(self, request: PreparedRequest):  # pylint: disable=unused-argument
         """Sleeps to rate-limit.
 
         Sleeps until the time specified in X-RateLimit-Reset.

--- a/tcex/sessions/tc_session.py
+++ b/tcex/sessions/tc_session.py
@@ -68,7 +68,7 @@ class TcSession(Session):
         # Add Retry
         self.retry()
 
-    def _log_curl(self, response: 'Response') -> None:
+    def _log_curl(self, response: 'Response'):
         """Log the curl equivalent command."""
 
         # don't show curl message for logging commands

--- a/tcex/tcex.py
+++ b/tcex/tcex.py
@@ -23,14 +23,10 @@ from tcex.exit.exit import ExitCode, ExitService
 from tcex.input.input import Input
 from tcex.key_value_store import KeyValueApi, KeyValueRedis, RedisClient
 from tcex.logger.logger import Logger  # pylint: disable=no-name-in-module
-from tcex.logger.trace_logger import TraceLogger  # pylint: disable=no-name-in-module
 from tcex.playbook import Playbook
 from tcex.pleb.proxies import proxies
 from tcex.pleb.registry import registry
 from tcex.pleb.scoped_property import scoped_property
-from tcex.services.api_service import ApiService
-from tcex.services.common_service_trigger import CommonServiceTrigger
-from tcex.services.webhook_trigger_service import WebhookTriggerService
 from tcex.sessions.auth.tc_auth import TcAuth
 from tcex.sessions.external_session import ExternalSession
 from tcex.sessions.tc_session import TcSession
@@ -40,6 +36,10 @@ from tcex.utils.file_operations import FileOperations
 
 if TYPE_CHECKING:
     # first-party
+    from tcex.logger.trace_logger import TraceLogger  # pylint: disable=no-name-in-module
+    from tcex.services.api_service import ApiService
+    from tcex.services.common_service_trigger import CommonServiceTrigger
+    from tcex.services.webhook_trigger_service import WebhookTriggerService
     from tcex.sessions.auth.hmac_auth import HmacAuth
     from tcex.sessions.auth.token_auth import TokenAuth
 
@@ -84,7 +84,7 @@ class TcEx:
         # log standard App info early so it shows at the top of the logfile
         self.logger.log_info(self.inputs.model_unresolved)
 
-    def _signal_handler(self, signal_interrupt: int, _) -> None:
+    def _signal_handler(self, signal_interrupt: int, _):
         """Handle signal interrupt."""
         call_file: str = os.path.basename(inspect.stack()[1][0].f_code.co_filename)
         call_module: str = inspect.stack()[1][0].f_globals['__name__'].lstrip('Functions.')
@@ -113,7 +113,7 @@ class TcEx:
         session: Session,
         output_prefix: str,
         timeout: Optional[int] = 600,
-    ) -> AdvancedRequest:
+    ) -> 'AdvancedRequest':
         """Return instance of AdvancedRequest.
 
         Args:
@@ -123,7 +123,7 @@ class TcEx:
         """
         return AdvancedRequest(self.inputs, self.playbook, session, output_prefix, timeout)
 
-    def exit(self, code: Optional[ExitCode] = None, msg: Optional[str] = None) -> None:
+    def exit(self, code: Optional[ExitCode] = None, msg: Optional[str] = None):
         """Application exit method with proper exit code
 
         The method will run the Python standard sys.exit() with the exit code
@@ -138,12 +138,12 @@ class TcEx:
         self.exit_service.exit(code, msg)  # pylint: disable=no-member
 
     @property
-    def exit_code(self) -> ExitCode:
+    def exit_code(self) -> 'ExitCode':
         """Return the current exit code."""
         return self.exit_service.exit_code  # pylint: disable=no-member
 
     @exit_code.setter
-    def exit_code(self, code: ExitCode) -> None:
+    def exit_code(self, code: 'ExitCode'):
         """Set the App exit code.
 
         For TC Exchange Apps there are 3 supported exit codes.
@@ -158,7 +158,7 @@ class TcEx:
 
     @registry.factory(ExitService)
     @scoped_property
-    def exit_service(self) -> ExitService:
+    def exit_service(self) -> 'ExitService':
         """Return an ExitService object."""
         # TODO: [high] @cblades - inputs being required for exit prevents AOT from exiting
         return self.get_exit_service(self.inputs)
@@ -169,13 +169,13 @@ class TcEx:
         return FileOperations(temp_path=self.inputs.model_unresolved.tc_temp_path)
 
     @staticmethod
-    def get_exit_service(inputs) -> ExitService:
+    def get_exit_service(inputs) -> 'ExitService':
         """Create an ExitService object."""
         return ExitService(inputs)
 
     def get_playbook(
         self, context: Optional[str] = None, output_variables: Optional[list] = None
-    ) -> Playbook:
+    ) -> 'Playbook':
         """Return a new instance of playbook module.
 
         Args:
@@ -189,7 +189,7 @@ class TcEx:
     @staticmethod
     def get_redis_client(
         host: str, port: int, db: int = 0, blocking_pool: bool = False, **kwargs
-    ) -> RedisClient:
+    ) -> 'RedisClient':
         """Return a *new* instance of Redis client.
 
         For a full list of kwargs see https://redis-py.readthedocs.io/en/latest/#redis.Connection.
@@ -220,7 +220,7 @@ class TcEx:
         proxies: Optional[Dict[str, str]] = None,  # pylint: disable=redefined-outer-name
         proxies_enabled: Optional[bool] = None,
         verify: Optional[Union[bool, str]] = None,
-    ) -> TcSession:
+    ) -> 'TcSession':
         """Return an instance of Requests Session configured for the ThreatConnect API.
 
         No args are required to get a working instance of TC Session instance.
@@ -253,7 +253,7 @@ class TcEx:
             verify=verify,
         )
 
-    def get_session_external(self) -> ExternalSession:
+    def get_session_external(self) -> 'ExternalSession':
         """Return an instance of Requests Session configured for the ThreatConnect API."""
         _session_external = ExternalSession()
 
@@ -273,13 +273,13 @@ class TcEx:
 
         return _session_external
 
-    # def get_ti(self) -> ThreatIntelligence:
+    # def get_ti(self) -> 'ThreatIntelligence':
     #     """Include the Threat Intel Module."""
     #     return ThreatIntelligence(session=self.get_session_tc())
 
     @registry.factory('KeyValueStore')
     @scoped_property
-    def key_value_store(self) -> Union[KeyValueApi, KeyValueRedis]:
+    def key_value_store(self) -> Union['KeyValueApi', 'KeyValueRedis']:
         """Return the correct KV store for this execution.
 
         The TCKeyValueAPI KV store is limited to two operations (create and read),
@@ -296,20 +296,20 @@ class TcEx:
         )
 
     @property
-    def log(self) -> TraceLogger:
+    def log(self) -> 'TraceLogger':
         """Return a valid logger."""
         if self._log is None:
             self._log = self.logger.log
         return self._log
 
     @log.setter
-    def log(self, log: object) -> None:
+    def log(self, log: object):
         """Return a valid logger."""
         if isinstance(log, logging.Logger):
             self._log = log
 
     @cached_property
-    def logger(self) -> Logger:
+    def logger(self) -> 'Logger':
         """Return logger."""
         _logger = Logger(logger_name='tcex')
 
@@ -391,7 +391,7 @@ class TcEx:
             db=0,
         )
 
-    def results_tc(self, key: str, value: str) -> None:
+    def results_tc(self, key: str, value: str):
         """Write data to results_tc file in TcEX specified directory.
 
         The TcEx platform support persistent values between executions of the App.  This
@@ -431,7 +431,7 @@ class TcEx:
             fh.truncate()
 
     @cached_property
-    def service(self) -> Union[ApiService, CommonServiceTrigger, WebhookTriggerService]:
+    def service(self) -> Union['ApiService', 'CommonServiceTrigger', 'WebhookTriggerService']:
         """Include the Service Module."""
         if self.ij.model.runtime_level.lower() == 'apiservice':
             from .services import ApiService as Service

--- a/tcex/tokens/tokens.py
+++ b/tcex/tokens/tokens.py
@@ -104,7 +104,7 @@ class Tokens:
             key: str = self.trigger_id
         return key
 
-    def register_token(self, key: str, token: Sensitive, expires: int) -> None:
+    def register_token(self, key: str, token: Sensitive, expires: int):
         """Register a token.
 
         Args:
@@ -124,7 +124,7 @@ class Tokens:
             f'token={token}, expiration={expires}'
         )
 
-    def renew_token(self, token: Sensitive) -> None:
+    def renew_token(self, token: Sensitive):
         """Renew expired ThreatConnect Token.
 
         This method will renew a token and update the token_map with new token and expiration.
@@ -185,7 +185,7 @@ class Tokens:
         return threading.current_thread().name
 
     @property
-    def token(self) -> Optional[Sensitive]:
+    def token(self) -> Optional['Sensitive']:
         """Return token for current thread."""
         # wait until renewal barrier is set to True (meaning no renewal is in progress). If already
         # true, then simply proceed.
@@ -219,7 +219,7 @@ class Tokens:
         raise exc
 
     @token.setter
-    def token(self, token: Sensitive) -> None:
+    def token(self, token: 'Sensitive'):
         """Set token for current thread."""
         self.token_map.setdefault(self.key, {})['token'] = Sensitive(token)
 
@@ -229,18 +229,18 @@ class Tokens:
         return self.token_map.get(self.key, {}).get('token_expires')
 
     @token_expires.setter
-    def token_expires(self, expires) -> None:
+    def token_expires(self, expires):
         """Set token expires for current thread."""
         self.token_map.setdefault(self.key, {})['token_expires'] = int(expires)
 
-    def token_renewal(self) -> None:
+    def token_renewal(self):
         """Start token renewal monitor thread."""
         self.monitor_thread = ExceptionThread(
             name='token-renewal', target=self.token_renewal_monitor, daemon=True
         )
         self.monitor_thread.start()
 
-    def token_renewal_monitor(self) -> None:
+    def token_renewal_monitor(self):
         """Monitor token expiration and renew when required."""
         self.log.debug('feature=token, event=renewal-monitor-started')
         self._barrier.set()
@@ -307,7 +307,7 @@ class Tokens:
             trigger_id = int(trigger_id)
         return trigger_id
 
-    def unregister_token(self, key: str) -> None:
+    def unregister_token(self, key: str):
         """Unregister a token.
 
         Args:

--- a/tcex/utils/requests_to_curl.py
+++ b/tcex/utils/requests_to_curl.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class RequestsToCurl:
     """TcEx Utilities Request to Curl Class"""
 
-    def __init__(self) -> None:
+    def __init__(self):
         """Initialize the Class properties."""
         self.utils = Utils()
 

--- a/tests/api/tc/v3/v3_helpers.py
+++ b/tests/api/tc/v3/v3_helpers.py
@@ -28,7 +28,7 @@ class V3Helper:
         v3_object: The name of the object (e.g., artifact) being tested.
     """
 
-    def __init__(self, v3_object: str) -> None:
+    def __init__(self, v3_object: str):
         """Initialize Class Properties"""
         self.app = MockApp(runtime_level='Playbook')
         self.tcex = self.app.tcex
@@ -256,7 +256,7 @@ class V3Helper:
         return _modules.get(module)
 
     @staticmethod
-    def assert_generator(model: 'BaseModel', object_name: str) -> None:
+    def assert_generator(model: 'BaseModel', object_name: str):
         """Print assert statements for the provided model.
 
         self.v3_helper.assert_generator(owner.model, 'owners')
@@ -270,7 +270,7 @@ class V3Helper:
                 value = f'\'{value}\''
             print(f'''{' ' * 8}assert {object_name}.model.{key} == {value}''')
 
-    def tql_generator(self, model: 'BaseModel', object_name: str) -> None:
+    def tql_generator(self, model: 'BaseModel', object_name: str):
         """Print TQL filter.
 
         group.get(params={'fields': ['_all_']})

--- a/tests/app_config/apps/tcpb/app_1/app_inputs.py
+++ b/tests/app_config/apps/tcpb/app_1/app_inputs.py
@@ -120,7 +120,7 @@ class Action4Model(AppBaseModel):
 class AppInputs:
     """App Inputs"""
 
-    def __init__(self, inputs: 'BaseModel') -> None:
+    def __init__(self, inputs: 'BaseModel'):
         """Initialize class properties."""
         self.inputs = inputs
 
@@ -135,7 +135,7 @@ class AppInputs:
         }
         return action_model_map.get(tc_action)
 
-    def update_inputs(self) -> None:
+    def update_inputs(self):
         """Add custom App models to inputs.
 
         Input will be validate when the model is added an any exceptions will

--- a/tests/app_config/test_install_json_model.py
+++ b/tests/app_config/test_install_json_model.py
@@ -75,7 +75,7 @@ class TestInstallJson:
             assert False, f'Failed parsing file {fqfn.name} ({ex})'
 
     @staticmethod
-    def model_validate(path: str) -> None:
+    def model_validate(path: str):
         """Validate input model in and out."""
         tcex_test_dir = os.getenv('TCEX_TEST_DIR')
         ij_path = Path(os.path.join(tcex_test_dir, path))
@@ -438,22 +438,22 @@ class TestInstallJson:
         """Test method"""
         assert self.ij(app_type='tcvc').model.service_playbook_params
 
-    def test_tc_support(self) -> None:
+    def test_tc_support(self):
         """Validate install.json files."""
         self.model_validate('app_config/apps/tc')
 
-    def test_tcpb_support(self) -> None:
+    def test_tcpb_support(self):
         """Validate install.json files."""
         self.model_validate('app_config/apps/tcpb')
 
-    def test_tcva_support(self) -> None:
+    def test_tcva_support(self):
         """Validate install.json files."""
         self.model_validate('app_config/apps/tcva')
 
-    def test_tcvc_support(self) -> None:
+    def test_tcvc_support(self):
         """Validate install.json files."""
         self.model_validate('app_config/apps/tcvc')
 
-    def test_tcvw_support(self) -> None:
+    def test_tcvw_support(self):
         """Validate install.json files."""
         self.model_validate('app_config/apps/tcvw')

--- a/tests/app_config/test_job_json_model.py
+++ b/tests/app_config/test_job_json_model.py
@@ -44,7 +44,7 @@ class TestJobJson:
             assert False, f'Failed parsing file {fqfn.name} ({ex})'
 
     @staticmethod
-    def model_validate(path: str) -> None:
+    def model_validate(path: str):
         """Validate input model in and out."""
         jj_path = Path(path)
         for fqfn in jj_path.glob('**/*job.json'):

--- a/tests/app_config/test_layout_json_model.py
+++ b/tests/app_config/test_layout_json_model.py
@@ -87,7 +87,7 @@ class TestLayoutJson:
             assert False, f'Failed parsing file {fqfn.name} ({ex})'
 
     @staticmethod
-    def model_validate(path: str) -> None:
+    def model_validate(path: str):
         """Validate input model in and out."""
         tcex_test_dir = os.getenv('TCEX_TEST_DIR')
         lj_path = Path(os.path.join(tcex_test_dir, path))

--- a/tests/app_config/test_tcex_json_model.py
+++ b/tests/app_config/test_tcex_json_model.py
@@ -80,7 +80,7 @@ class TestTcexJson:
             assert False, f'Failed parsing file {fqfn.name} ({ex})'
 
     @staticmethod
-    def model_validate(path: str) -> None:
+    def model_validate(path: str):
         """Validate input model in and out."""
         tcex_test_dir = os.getenv('TCEX_TEST_DIR')
         tj_path = Path(os.path.join(tcex_test_dir, path))

--- a/tests/bin/test_tcex_deps.py
+++ b/tests/bin/test_tcex_deps.py
@@ -28,7 +28,7 @@ runner = CliRunner()
 class TestTcexCliDeps:
     """Tcex CLI Testing."""
 
-    def teardown_method(self) -> None:
+    def teardown_method(self):
         """Configure teardown before all tests."""
         # cleanup
         for lib_dir in Path('.').glob('lib_*'):
@@ -63,14 +63,14 @@ class TestTcexCliDeps:
 
     def test_tcex_deps_std(
         self, monkeypatch: 'pytest.Monkeypatch', request: 'pytest.FixtureRequest'
-    ) -> None:
+    ):
         """Test Case"""
         result = self._run_command(['deps'], 'app_std', monkeypatch, request)
         assert result.exit_code == 0
 
     def test_tcex_deps_branch(
         self, monkeypatch: 'pytest.Monkeypatch', request: 'pytest.FixtureRequest'
-    ) -> None:
+    ):
         """Test Case"""
         branch = 'develop'
         result = self._run_command(['deps', '--branch', branch], 'app_branch', monkeypatch, request)
@@ -88,7 +88,7 @@ class TestTcexCliDeps:
 
     def test_tcex_deps_proxy(
         self, monkeypatch: 'pytest.Monkeypatch', request: 'pytest.FixtureRequest'
-    ) -> None:
+    ):
         """Test Case"""
         proxy_host = os.getenv('TC_PROXY_HOST')
         proxy_port = os.getenv('TC_PROXY_PORT')

--- a/tests/bin/test_tcex_init.py
+++ b/tests/bin/test_tcex_init.py
@@ -40,7 +40,7 @@ class TestTcexCliInit:
         result = runner.invoke(app, args)
         return result
 
-    def test_tcex_init_organization_basic(self, monkeypatch: 'pytest.MonkeyPatch') -> None:
+    def test_tcex_init_organization_basic(self, monkeypatch: 'pytest.MonkeyPatch'):
         """Test Case"""
         result = self._run_command(
             ['init', '--type', 'organization', '--template', 'basic', '--force'], monkeypatch
@@ -53,7 +53,7 @@ class TestTcexCliInit:
         assert os.path.isfile('job_app.py')
         assert os.path.isfile('tcex.json')
 
-    def test_tcex_init_playbook_basic(self, monkeypatch: 'pytest.Monkeypatch') -> None:
+    def test_tcex_init_playbook_basic(self, monkeypatch: 'pytest.Monkeypatch'):
         """Test Case"""
         result = self._run_command(
             ['init', '--type', 'playbook', '--template', 'basic'], monkeypatch

--- a/tests/bin/test_tcex_list.py
+++ b/tests/bin/test_tcex_list.py
@@ -36,7 +36,7 @@ class TestTcexCliList:
         result = runner.invoke(app, args)
         return result
 
-    def test_tcex_list(self) -> None:
+    def test_tcex_list(self):
         """Test Case"""
         result = self._run_command(['list'])
         assert result.exit_code == 0, result.stdout
@@ -51,7 +51,7 @@ class TestTcexCliList:
         # assert 'Webhook Trigger Service Templates' in result.stdout
 
     # TODO: [med] update this once template is done
-    # def test_tcex_list_external_api_service(self) -> None:
+    # def test_tcex_list_external_api_service(self):
     #     """Test Case"""
     #     result = self._run_command(['list', '--type', 'api_service'])
     #     assert result.exit_code == 0, result.stdout
@@ -60,7 +60,7 @@ class TestTcexCliList:
     #     assert 'basic' in result.stdout
 
     # TODO: [med] update this once template is done
-    # def test_tcex_list_external_basic(self) -> None:
+    # def test_tcex_list_external_basic(self):
     #     """Test Case"""
     #     result = self._run_command(['list', '--type', 'external'])
     #     assert result.exit_code == 0, result.stdout
@@ -68,7 +68,7 @@ class TestTcexCliList:
     #     # spot check a few lines of outputs
     #     assert 'basic' in result.stdout
 
-    def test_tcex_list_organization_basic(self) -> None:
+    def test_tcex_list_organization_basic(self):
         """Test Case"""
         result = self._run_command(['list', '--type', 'organization'])
         assert result.exit_code == 0, result.stdout
@@ -76,7 +76,7 @@ class TestTcexCliList:
         # spot check a few lines of outputs
         assert 'basic' in result.stdout
 
-    def test_tcex_list_playbook_basic(self) -> None:
+    def test_tcex_list_playbook_basic(self):
         """Test Case"""
         result = self._run_command(['list', '--type', 'playbook'])
         assert result.exit_code == 0, f'{result.stdout}'
@@ -85,7 +85,7 @@ class TestTcexCliList:
         assert 'basic' in result.stdout
 
     # TODO: [med] update this once template is done
-    # def test_tcex_list_trigger_basic(self) -> None:
+    # def test_tcex_list_trigger_basic(self):
     #     """Test Case"""
     #     result = self._run_command(['list', '--type', 'trigger_service'])
     #     assert result.exit_code == 0, result.stdout
@@ -94,7 +94,7 @@ class TestTcexCliList:
     #     assert 'basic' in result.stdout
 
     # TODO: [med] update this once template is done
-    # def test_tcex_list_webhook_trigger_basic(self) -> None:
+    # def test_tcex_list_webhook_trigger_basic(self):
     #     """Test Case"""
     #     result = self._run_command(['list', '--type', 'webhook_trigger_service'])
     #     assert result.exit_code == 0, result.stdout

--- a/tests/mock_app.py
+++ b/tests/mock_app.py
@@ -34,7 +34,7 @@ class MockApp:
         ij_data (dict, kwargs): Additional install.json data.
     """
 
-    def __init__(self, runtime_level: str, **kwargs) -> None:
+    def __init__(self, runtime_level: str, **kwargs):
         """Initialize class properties."""
         self.runtime_level = runtime_level
         self.cd: dict = kwargs.get('config_data', {})  # configuration data for tcex instance
@@ -241,7 +241,7 @@ class MockApp:
             },
         }
 
-    def _write_file_params_encrypted_file(self, config: dict) -> None:
+    def _write_file_params_encrypted_file(self, config: dict):
         """Write the App encrypted fileParams file."""
         config_data = json.dumps(config).encode()
         config_key = self.utils.random_string(16)
@@ -259,7 +259,7 @@ class MockApp:
         os.environ['TC_APP_PARAM_KEY'] = config_key
 
     @staticmethod
-    def _write_install_json(data: dict) -> None:
+    def _write_install_json(data: dict):
         """Write the App install.json file."""
         with open('install.json', 'w') as fh:
             json.dump(data, fh, indent=2, sort_keys=True)

--- a/tests/playbook/test_playbook_embedded_variables.py
+++ b/tests/playbook/test_playbook_embedded_variables.py
@@ -20,7 +20,7 @@ class TestEmbedded:
         print('\n')  # print blank line for readability
 
     @staticmethod
-    def stage_data(tcex: 'TcEx') -> None:
+    def stage_data(tcex: 'TcEx'):
         """Configure setup before all tests."""
         out_variables = []
         tcex.inputs.model.tc_playbook_out_variables = ','.join(out_variables)
@@ -172,7 +172,7 @@ class TestEmbedded:
             ('#App:0001:array.1!StringArray', ['two', 'three']),
         ],
     )
-    def test_embedded_read_string(self, embedded_value: str, expected: Any, tcex: 'TcEx') -> None:
+    def test_embedded_read_string(self, embedded_value: str, expected: Any, tcex: 'TcEx'):
         """Test playbook variables."""
         playbook: 'Playbook' = tcex.playbook
         self.stage_data(tcex)

--- a/tests/sessions/test_session_tc.py
+++ b/tests/sessions/test_session_tc.py
@@ -13,7 +13,7 @@ class TestUtils:
     """Test the TcEx Session Module."""
 
     @staticmethod
-    def test_session_token_auth(tcex: 'TcEx') -> None:
+    def test_session_token_auth(tcex: 'TcEx'):
         """Test tc.session property
 
         Args:
@@ -24,7 +24,7 @@ class TestUtils:
         assert r.status_code == 200
 
     @staticmethod
-    def test_session_hmac_auth(tcex_hmac: 'TcEx') -> None:
+    def test_session_hmac_auth(tcex_hmac: 'TcEx'):
         """Test tc.session property with hmac auth
 
         Args:
@@ -35,7 +35,7 @@ class TestUtils:
         assert r.status_code == 200
 
     @staticmethod
-    def test_session_proxy(tcex_proxy: 'TcEx') -> None:
+    def test_session_proxy(tcex_proxy: 'TcEx'):
         """Test tc.session property
 
         Args:

--- a/tests/tcex_methods/test_message_tc.py
+++ b/tests/tcex_methods/test_message_tc.py
@@ -15,7 +15,7 @@ class TestMessageTc:
         """Configure setup before all tests."""
 
     @staticmethod
-    def test_message_tc(tcex: 'TcEx') -> None:
+    def test_message_tc(tcex: 'TcEx'):
         """Test message tc method.
 
         Args:
@@ -48,7 +48,7 @@ class TestMessageTc:
         assert message == message_tc, 'message.tc did not match message'
 
     @staticmethod
-    def test_message_tc_long_message(tcex: 'TcEx') -> None:
+    def test_message_tc_long_message(tcex: 'TcEx'):
         """Test long provided to message.tc method.
 
         Args:
@@ -86,7 +86,7 @@ class TestMessageTc:
         assert message[-255:] == message_tc, 'message.tc did not match message'
 
     @staticmethod
-    def test_message_tc_multiple_messages(tcex: 'TcEx') -> None:
+    def test_message_tc_multiple_messages(tcex: 'TcEx'):
         """Test long provided to message.tc method.
 
         Args:

--- a/tests/tokens/test_token.py
+++ b/tests/tokens/test_token.py
@@ -282,9 +282,6 @@ class TestToken:
         request is reattempted, tc_session should request a new token from tokens.py, and tokens.py
         should only return the new token after the renewal process is complete. This test exercises
         this scenario.
-
-        Args:
-            service_app (MockApp, fixture): An instantiated instance of MockApp.
         """
 
         # reduce the amount of time between token renewal cycles, but make it long enough


### PR DESCRIPTION
- Removed return typing hint  when set to "-> None:". This being the default value it's more readable when not included.
- Updated to use forward reference in typing hints until a later version where default of annotations can be used.