### PR TITLE
spectool updates

### DIFF
--- a/tcex/app_config/app_spec_yml.py
+++ b/tcex/app_config/app_spec_yml.py
@@ -480,10 +480,13 @@ class AppSpecYml:
         if 'appId' in contents and contents.get('appId') is None:
             del contents['appId']
 
+        # exclude_defaults - if False then all unused fields are added in - not good.
+        # exclude_none - this should be safe to leave as True.
+        # exclude_unset - this should be False to ensure that all fields are included.
         contents = json.loads(
             AppSpecYmlModel(**contents).json(
                 by_alias=True,
-                exclude_defaults=False,
+                exclude_defaults=True,
                 exclude_none=True,
                 exclude_unset=False,
                 sort_keys=True,

--- a/tcex/app_config/models/job_json_model.py
+++ b/tcex/app_config/models/job_json_model.py
@@ -28,6 +28,8 @@ class ParamsModel(BaseModel):
         """DataModel Config"""
 
         alias_generator = snake_to_camel
+        # without smart_union the default value as a string of "0" would be converted to a bool
+        smart_union = True
         validate_assignment = True
 
 

--- a/tcex/app_config/models/job_json_model.py
+++ b/tcex/app_config/models/job_json_model.py
@@ -4,7 +4,7 @@
 from typing import List, Optional, Union
 
 # third-party
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, Field, validator
 from semantic_version import Version
 
 __all__ = ['JobJsonModel']
@@ -36,16 +36,41 @@ class ParamsModel(BaseModel):
 class JobJsonCommonModel(BaseModel):
     """Model for common field in job.json."""
 
-    allow_on_demand: bool = False
-    enable_notifications: bool = False
+    allow_on_demand: bool = Field(
+        ...,
+        description='If true, the job can be run on demand.',
+    )
+    enable_notifications: bool = Field(
+        ..., description='Enables pass/fail notifications for this job.'
+    )
     job_name: str
-    notify_email: str = ''
-    notify_include_log_files: bool = False
-    notify_on_complete: bool = False
-    notify_on_failure: bool = False
-    notify_on_partial_failure: bool = False
+    notify_email: str = Field(
+        ...,
+        description='Email address to send notifications to.',
+    )
+    notify_include_log_files: bool = Field(
+        ...,
+        description='If true, the job log files will be included in the notification email.',
+    )
+    notify_on_complete: bool = Field(
+        ...,
+        description='If true, a notification will be sent when the job completes.',
+    )
+    notify_on_failure: bool = Field(
+        ...,
+        description='If true, a notification will be sent when the job fails.',
+    )
+    notify_on_partial_failure: bool = Field(
+        ...,
+        description=(
+            'If true, a notification will be sent when the job completes with partial success.'
+        ),
+    )
     params: List[ParamsModel]
-    publish_auth: bool = False
+    publish_auth: bool = Field(
+        ...,
+        description='If true, the job will publish the authentication token.',
+    )
     schedule_cron_format: str
     schedule_start_date: int
     schedule_type: str


### PR DESCRIPTION
- fixed generation of job.json by making more fields required without a default.
- changed output of app_spec to not include defaults. this required changes to models when core required the fields to be present event when they are defaulted.