### PR TITLE
Relax Pydantic Version Requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "jmespath",
   "paho-mqtt<2.0.0",
   "pyaes",
-  "pydantic<2.0.0",
+  "pydantic (>=1.10.17,<3.0.0)",
   "python-dateutil",
   "PyYAML",
   "redis<5.0.0",

--- a/tcex/api/tc/ti_transform/model/transform_model.py
+++ b/tcex/api/tc/ti_transform/model/transform_model.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 # third-party
 from jmespath import compile as jmespath_compile
-from pydantic import BaseModel, Extra, Field, root_validator, validator
+from pydantic.v1 import BaseModel, Extra, Field, root_validator, validator
 
 
 # reusable validator

--- a/tcex/api/tc/v3/_gen/_gen_abc.py
+++ b/tcex/api/tc/v3/_gen/_gen_abc.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from textwrap import TextWrapper
 
 # third-party
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from requests import Session
 from requests.exceptions import ProxyError
 

--- a/tcex/api/tc/v3/_gen/_gen_filter_abc.py
+++ b/tcex/api/tc/v3/_gen/_gen_filter_abc.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 from typing import Any
 
 # third-party
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from requests.exceptions import ProxyError
 
 # first-party

--- a/tcex/api/tc/v3/_gen/model/_filter_model.py
+++ b/tcex/api/tc/v3/_gen/model/_filter_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Extra, Field, validator
+from pydantic.v1 import BaseModel, Extra, Field, validator
 
 # first-party
 from tcex.pleb.cached_property import cached_property

--- a/tcex/api/tc/v3/_gen/model/_property_model.py
+++ b/tcex/api/tc/v3/_gen/model/_property_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Extra, Field, validator
+from pydantic.v1 import BaseModel, Extra, Field, validator
 
 # first-party
 from tcex.pleb.cached_property import cached_property

--- a/tcex/api/tc/v3/artifact_types/artifact_type_model.py
+++ b/tcex/api/tc/v3/artifact_types/artifact_type_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/artifacts/artifact_model.py
+++ b/tcex/api/tc/v3/artifacts/artifact_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/attribute_types/attribute_type_model.py
+++ b/tcex/api/tc/v3/attribute_types/attribute_type_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/attributes/attribute_model.py
+++ b/tcex/api/tc/v3/attributes/attribute_model.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field
+from pydantic.v1 import BaseModel, Extra, Field
 
 # first-party
 from tcex.util import Util

--- a/tcex/api/tc/v3/case_attributes/case_attribute_model.py
+++ b/tcex/api/tc/v3/case_attributes/case_attribute_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/cases/case_model.py
+++ b/tcex/api/tc/v3/cases/case_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/file_actions/file_action_model.py
+++ b/tcex/api/tc/v3/file_actions/file_action_model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/file_occurrences/file_occurrence_model.py
+++ b/tcex/api/tc/v3/file_occurrences/file_occurrence_model.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/group_attributes/group_attribute_model.py
+++ b/tcex/api/tc/v3/group_attributes/group_attribute_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/groups/group_model.py
+++ b/tcex/api/tc/v3/groups/group_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/indicator_attributes/indicator_attribute_model.py
+++ b/tcex/api/tc/v3/indicator_attributes/indicator_attribute_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/indicators/indicator_model.py
+++ b/tcex/api/tc/v3/indicators/indicator_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/intel_requirements/categories/category_model.py
+++ b/tcex/api/tc/v3/intel_requirements/categories/category_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/intel_requirements/intel_req_type_model.py
+++ b/tcex/api/tc/v3/intel_requirements/intel_req_type_model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 
 # third-party
-from pydantic import Extra, Field
+from pydantic.v1 import Extra, Field
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/intel_requirements/intel_requirement_model.py
+++ b/tcex/api/tc/v3/intel_requirements/intel_requirement_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/intel_requirements/keyword_sections/keyword_section_model.py
+++ b/tcex/api/tc/v3/intel_requirements/keyword_sections/keyword_section_model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 
 # third-party
-from pydantic import Field, PrivateAttr
+from pydantic.v1 import Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/intel_requirements/results/result_model.py
+++ b/tcex/api/tc/v3/intel_requirements/results/result_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/intel_requirements/subtypes/subtype_model.py
+++ b/tcex/api/tc/v3/intel_requirements/subtypes/subtype_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/notes/note_model.py
+++ b/tcex/api/tc/v3/notes/note_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/security/assignee_model.py
+++ b/tcex/api/tc/v3/security/assignee_model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 
 # third-party
-from pydantic import Field, validator
+from pydantic.v1 import Field, validator
 
 # first-party
 from tcex.api.tc.v3.security.assignee_user_group_model import AssigneeUserGroupModel

--- a/tcex/api/tc/v3/security/assignee_user_group_model.py
+++ b/tcex/api/tc/v3/security/assignee_user_group_model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 
 # third-party
-from pydantic import Field
+from pydantic.v1 import Field
 
 # first-party
 from tcex.api.tc.v3.security.user_groups.user_group_model import UserGroupModel

--- a/tcex/api/tc/v3/security/assignee_user_model.py
+++ b/tcex/api/tc/v3/security/assignee_user_model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 
 # third-party
-from pydantic import Field
+from pydantic.v1 import Field
 
 # first-party
 from tcex.api.tc.v3.security.users.user_model import UserModel

--- a/tcex/api/tc/v3/security/owner_roles/owner_role_model.py
+++ b/tcex/api/tc/v3/security/owner_roles/owner_role_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/security/owners/owner_model.py
+++ b/tcex/api/tc/v3/security/owners/owner_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/security/system_roles/system_role_model.py
+++ b/tcex/api/tc/v3/security/system_roles/system_role_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/security/task_assignee_model.py
+++ b/tcex/api/tc/v3/security/task_assignee_model.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import Enum
 
 # third-party
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.security.users.user_model import UserModel

--- a/tcex/api/tc/v3/security/user_groups/user_group_model.py
+++ b/tcex/api/tc/v3/security/user_groups/user_group_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/security/users/user_model.py
+++ b/tcex/api/tc/v3/security/users/user_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/security_labels/security_label_model.py
+++ b/tcex/api/tc/v3/security_labels/security_label_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/tags/mitre_tags.py
+++ b/tcex/api/tc/v3/tags/mitre_tags.py
@@ -5,7 +5,7 @@ import logging
 import re
 
 # third-party
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 # first-party
 from tcex.logger.trace_logger import TraceLogger

--- a/tcex/api/tc/v3/tags/naics_tags.py
+++ b/tcex/api/tc/v3/tags/naics_tags.py
@@ -4,7 +4,7 @@
 import logging
 
 # third-party
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 # first-party
 from tcex.logger.trace_logger import TraceLogger

--- a/tcex/api/tc/v3/tags/tag_model.py
+++ b/tcex/api/tc/v3/tags/tag_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/tasks/task_model.py
+++ b/tcex/api/tc/v3/tasks/task_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/v3_model_abc.py
+++ b/tcex/api/tc/v3/v3_model_abc.py
@@ -10,7 +10,7 @@ from json import JSONEncoder
 from typing import Any, Self
 
 # third-party
-from pydantic import BaseModel, PrivateAttr
+from pydantic.v1 import BaseModel, PrivateAttr
 
 # first-party
 from tcex.logger.trace_logger import TraceLogger

--- a/tcex/api/tc/v3/victim_assets/victim_asset_model.py
+++ b/tcex/api/tc/v3/victim_assets/victim_asset_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/victim_attributes/victim_attribute_model.py
+++ b/tcex/api/tc/v3/victim_attributes/victim_attribute_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/victims/victim_model.py
+++ b/tcex/api/tc/v3/victims/victim_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/workflow_events/workflow_event_model.py
+++ b/tcex/api/tc/v3/workflow_events/workflow_event_model.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/api/tc/v3/workflow_templates/workflow_template_model.py
+++ b/tcex/api/tc/v3/workflow_templates/workflow_template_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-member,no-self-argument,wrong-import-position
 # third-party
-from pydantic import BaseModel, Extra, Field, PrivateAttr, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, validator
 
 # first-party
 from tcex.api.tc.v3.v3_model_abc import V3ModelABC

--- a/tcex/input/input.py
+++ b/tcex/input/input.py
@@ -9,8 +9,8 @@ from base64 import b64decode
 from pathlib import Path
 
 # third-party
-from pydantic import ValidationError  # TYPE-CHECKING
-from pydantic import BaseModel, Extra
+from pydantic.v1 import ValidationError  # TYPE-CHECKING
+from pydantic.v1 import BaseModel, Extra
 
 # first-party
 from tcex.app.config.install_json import InstallJson
@@ -232,7 +232,7 @@ class Input:
         self.contents_update(_inputs)
         return dict(sorted(_inputs.items()))
 
-    # TODO: [high] - can this be replaced with a pydantic root validator?
+    # TODO: [high] - can this be replaced with a pydantic.v1 root validator?
     def contents_update(self, inputs: dict):
         """Update inputs provided by core to be of the proper value and type."""
         for name, value in inputs.items():

--- a/tcex/input/model/advanced_request_model.py
+++ b/tcex/input/model/advanced_request_model.py
@@ -5,7 +5,7 @@
 from typing import Any
 
 # third-party
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 # first-party
 from tcex.input.field_type import EditChoice

--- a/tcex/input/model/api_model.py
+++ b/tcex/input/model/api_model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-self-argument
 
 # third-party
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 # first-party
 from tcex.app.config.install_json import InstallJson

--- a/tcex/input/model/batch_model.py
+++ b/tcex/input/model/batch_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class BatchModel(BaseModel):

--- a/tcex/input/model/cal_setting_model.py
+++ b/tcex/input/model/cal_setting_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 # first-party
 from tcex.input.field_type.sensitive import Sensitive

--- a/tcex/input/model/cert_model.py
+++ b/tcex/input/model/cert_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class CertModel(BaseModel):

--- a/tcex/input/model/create_config_model.py
+++ b/tcex/input/model/create_config_model.py
@@ -5,7 +5,7 @@
 from typing import Any
 
 # third-party
-from pydantic import BaseModel, Extra, root_validator, validator
+from pydantic.v1 import BaseModel, Extra, root_validator, validator
 
 # first-party
 from tcex.app.config import InstallJson

--- a/tcex/input/model/logging_model.py
+++ b/tcex/input/model/logging_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class LoggingModel(BaseModel):

--- a/tcex/input/model/module_app_model.py
+++ b/tcex/input/model/module_app_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import Extra
+from pydantic.v1 import Extra
 
 # first-party
 from tcex.input.model.api_model import ApiModel

--- a/tcex/input/model/module_requests_session_model.py
+++ b/tcex/input/model/module_requests_session_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import Extra
+from pydantic.v1 import Extra
 
 # first-party
 from tcex.input.model.api_model import ApiModel

--- a/tcex/input/model/organization_model.py
+++ b/tcex/input/model/organization_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class OrganizationModel(BaseModel):

--- a/tcex/input/model/path_model.py
+++ b/tcex/input/model/path_model.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class PathModel(BaseModel):

--- a/tcex/input/model/playbook_common_model.py
+++ b/tcex/input/model/playbook_common_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 # first-party
 from tcex.input.field_type.sensitive import Sensitive

--- a/tcex/input/model/playbook_model.py
+++ b/tcex/input/model/playbook_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 
 class PlaybookModel(BaseModel):

--- a/tcex/input/model/proxy_model.py
+++ b/tcex/input/model/proxy_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 # first-party
 from tcex.input.field_type.sensitive import Sensitive

--- a/tcex/input/model/service_model.py
+++ b/tcex/input/model/service_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 # first-party
 from tcex.input.field_type.sensitive import Sensitive

--- a/tcex/input/model/smtp_setting_model.py
+++ b/tcex/input/model/smtp_setting_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 # first-party
 from tcex.input.field_type.sensitive import Sensitive

--- a/tests/api/tc/v3/v3_helpers.py
+++ b/tests/api/tc/v3/v3_helpers.py
@@ -11,7 +11,7 @@ from typing import Any
 
 # third-party
 from _pytest.fixtures import FixtureRequest
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 # first-party
 from tcex.api.tc.v3.tql.tql_operator import TqlOperator

--- a/tests/app/config/apps/tcpb/app_1/app_inputs.py
+++ b/tests/app/config/apps/tcpb/app_1/app_inputs.py
@@ -5,7 +5,7 @@
 from typing import Any
 
 # third-party
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 # first-party
 from tcex.input.field_type import (

--- a/tests/input/field_type/advanced_settings/test_advanced_settings.py
+++ b/tests/input/field_type/advanced_settings/test_advanced_settings.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 # third-party
 import pytest
-from pydantic import BaseModel, Extra, ValidationError
+from pydantic.v1 import BaseModel, Extra, ValidationError
 
 # first-party
 from tcex.input.field_type import DateTime, String, modify_advanced_settings

--- a/tests/input/field_type/test_field_type_binary.py
+++ b/tests/input/field_type/test_field_type_binary.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 # third-party
 import pytest
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 # first-party
 from tcex.input.field_type import Binary, always_array, binary, conditional_required

--- a/tests/input/field_type/test_field_type_choice.py
+++ b/tests/input/field_type/test_field_type_choice.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 # third-party
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic.v1 import BaseModel, ValidationError
 
 # first-party
 from tcex.input.field_type import Choice, choice

--- a/tests/input/field_type/test_field_type_datetime.py
+++ b/tests/input/field_type/test_field_type_datetime.py
@@ -10,7 +10,7 @@ from operator import add, sub
 import arrow
 import pytest
 from dateutil.relativedelta import relativedelta
-from pydantic import BaseModel, ValidationError
+from pydantic.v1 import BaseModel, ValidationError
 
 # first-party
 from tcex import TcEx  # TYPE-CHECKING

--- a/tests/input/field_type/test_field_type_edit_choice.py
+++ b/tests/input/field_type/test_field_type_edit_choice.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 # third-party
 import pytest
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 # first-party
 from tcex.input.field_type import EditChoice, edit_choice

--- a/tests/input/field_type/test_field_type_integer.py
+++ b/tests/input/field_type/test_field_type_integer.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 # third-party
 import pytest
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 # first-party
 from tcex.input.field_type import Integer, always_array, integer

--- a/tests/input/field_type/test_field_type_ip_address.py
+++ b/tests/input/field_type/test_field_type_ip_address.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 # third-party
 import pytest
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 # first-party
 from tcex.input.field_type import AddressEntity, IpAddress, always_array, entity_input, ip_address

--- a/tests/input/field_type/test_field_type_key_value.py
+++ b/tests/input/field_type/test_field_type_key_value.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 # third-party
 import pytest
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 # first-party
 from tcex.input.field_type import KeyValue, TCEntity

--- a/tests/input/field_type/test_field_type_sensitive.py
+++ b/tests/input/field_type/test_field_type_sensitive.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 # third-party
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic.v1 import BaseModel, ValidationError
 
 # first-party
 from tcex.input.field_type import Sensitive

--- a/tests/input/field_type/test_field_type_string.py
+++ b/tests/input/field_type/test_field_type_string.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 # third-party
 import pytest
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 # first-party
 from tcex.input.field_type import String, always_array, conditional_required, string

--- a/tests/input/field_type/test_field_type_tcentity.py
+++ b/tests/input/field_type/test_field_type_tcentity.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 # third-party
 import pytest
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 # first-party
 from tcex.input.field_type import (

--- a/tests/input/field_type/util.py
+++ b/tests/input/field_type/util.py
@@ -6,7 +6,7 @@ from typing import Any
 
 # third-party
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic.v1 import BaseModel, ValidationError
 
 # first-party
 from tcex.input.field_type.sensitive import Sensitive


### PR DESCRIPTION
Pydantic v2 has been around for nearly 2 years, and as such many things use the new version. `tcex` and the associated repositories related to it all have a strict `<2.0.0` requirement on Pydantic, which is problematic when trying to utilize these libraries in a larger application or ecosystem which uses a newer version of Pydantic.

This PR and a collection of others I am in the process of making together aim to relax the version requirements for Pydantic by utilizing the `pydantic.v1` namespace introduced in `v1.10.17`. This `pyandic.v1` namespace allows users to utilize Pydantic as it was in v1 even when v2 is installed. It is explicitly listed as an option in the official [Migration Guide](https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment).

I plan to place this same PR description across all repositories which I found that needed updating, so here's some overarching information about this process as I have been able to understand it:

1. There are three "primary" projects which define Python packages: `tcex`, `tcex-cli`, and `tcex-app-testing`.
2. The primary projects need their `pyproject.toml` updated to relax the requirements to `>=1.10.17,<3.0.0`.
3. Secondary projects are used as submodules within the primary projects. The submodule projects that have references to pydantic are (as far as I could find): `tcex-app-config`, `tcex-app-playbook`, `tcex-util`.
4. All projects (primary and secondary) need all references to importing `pydantic` updated to reference `pydantic.v1`.

This is all relatively straightforward. In the forks I have made, I've run the following straightforward one-liner to replace all `from pydantic...` lines appropriately:

```sh
find . -name '*.py' | while read filepath; do
  sed 's/^from pydantic/from pydantic.v1/g' -i "$filepath"
done
```

For repositories with submodules (the primary repositories mentioned above), I filtered out the submodule paths before making this replacement. After the secondary repositories are merged, the primary repository submodules will also need to be updated to account for these changes in the primary repositories as well.

I will be the first to admit that I am not the best person to test all of this as I'm not intimately familiar with `tcex` or all the in's and out's of your application(s). But I am familiar with Pydantic, and this version conflict is a bump in the road for me, so I'm happy to work through troubleshooting. I'm happy to discuss options and work with the team, but given that this was just a bunch of find-and-replace followed by careful coordination of submodules, I figured I'd at least get the ball rolling.

Once all six of the PRs are open, I'll go back through and make a comment on each to reference the others so they can be properly tracked/linked.