### PR TITLE
Assign `data._staged` after storing in assignee for `Case.stage_assignee`

### DIFF
--- a/tcex/api/tc/v3/cases/case.py
+++ b/tcex/api/tc/v3/cases/case.py
@@ -198,10 +198,11 @@ class Case(ObjectABC):
         if not isinstance(data, UserModel | UserGroupModel):
             ex_msg = 'Invalid type passed in to stage_assignee'
             raise RuntimeError(ex_msg)  # noqa: TRY004
-        data._staged = True  # noqa: SLF001
+
         self.model.assignee._staged = True  # noqa: SLF001
         self.model.assignee.type = type
         self.model.assignee.data = data  # type: ignore
+        self.model.assignee.data._staged = True
 
     def stage_associated_case(self, data: dict | ObjectABC | CaseModel):
         """Stage case on the object."""


### PR DESCRIPTION
The value of `data._staged` is lost after assigning to `self.model.assignee.data`. This is likely because Pydantic is configured to validate assignments, and `_staged` is a `PrivateAttr`. The result is that underlying `data` object is copied by value and not by reference, and `_staged` is initialized with it's default value of `False.` You can validate this by printing `id(data)` and `id(self.model.assignee.data)` after the assignment.

This was causing the staged assignee changes to not be propagated upon calling `case.update()` as expected (since the underlying data was not marked as "staged").